### PR TITLE
Add `meta_arguments` to @parameter.inner for Rust

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -86,3 +86,6 @@
 
 (arguments
   (_) @parameter.inner)
+
+(meta_arguments
+  (_) @parameter.inner)


### PR DESCRIPTION
Related to https://github.com/nvim-treesitter/nvim-treesitter/issues/544

```rust
#[derive(Debug, PartialEq)]
struct Test {}

fn main() {
}
```

For example, switching `Debug` and `PartialEq`