### PR TITLE
Fix update-readme.lua

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -22,6 +22,9 @@ jobs:
           cd ~/.local/share/nvim/site/pack/nvim-treesitter/start
           git clone https://github.com/nvim-treesitter/nvim-treesitter.git
 
+      - name: Compile parsers
+        run: ./nvim.appimage --headless -c "TSInstallSync all" -c "q"
+
       # inspired by nvim-lspconfigs
       - name: Check README
         env:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ EOF
 <tr>
 <td>python</td><td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> </tr>
 <tr>
+<td>ql</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
+<tr>
 <td>Tree-sitter query language</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 <tr>
 <td>regex</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>

--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -33,9 +33,11 @@ for _, v in ipairs(sorted_parsers) do
   generated_text = generated_text..'<tr>\n'
   generated_text = generated_text..'<td>'..lang..'</td>'
 
+  local parsed_queries = query.get_query(lang, 'textobjects')
+  local found_textobjects = parsed_queries and parsed_queries.captures or {}
+
   for _, o in ipairs(textobjects) do
-    local query_string = query.get_query_string(lang, 'textobjects')
-    local found = query_string:find(o, 1, true)
+    local found = vim.tbl_contains(found_textobjects, o:sub(2))
     generated_text = generated_text..'<td>'..(found and '👍' or ' ')..'</td> '
   end
   generated_text = generated_text..'</tr>\n'


### PR DESCRIPTION
The new version no longer requires exposing
`nvim-treesitter.query.get_query_string`.

https://github.com/nvim-treesitter/nvim-treesitter/pull/515#discussion_r492550885