### PR TITLE
Fix #13: Support textobjects defined by start/end node

### DIFF
--- a/queries/dart/textobjects.scm
+++ b/queries/dart/textobjects.scm
@@ -1,0 +1,5 @@
+(
+  [(method_signature) (function_signature)] @function.outer.start
+  .
+  (function_body) @function.outer.end
+) 


### PR DESCRIPTION
Requires https://github.com/nvim-treesitter/nvim-treesitter/pull/553

This does not fix the "requires refactor" problem of that function.