### PR TITLE
queries/go: add @parameter.inner

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ EOF
 <tr>
 <td>fennel</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 <tr>
-<td>go</td><td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td> </td> <td>👍</td> </tr>
+<td>go</td><td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> </tr>
 <tr>
 <td>haskell</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 <tr>

--- a/queries/go/textobjects.scm
+++ b/queries/go/textobjects.scm
@@ -48,3 +48,22 @@
 
 ;; calls
 (call_expression (_)? @call.inner) @call.outer
+
+;; parameters
+(parameter_list
+  (parameter_declaration) @parameter.inner)
+
+(parameter_declaration
+  (identifier)
+  (identifier) @parameter.inner)
+
+(parameter_declaration
+  (identifier) @parameter.inner
+  (identifier))
+
+(parameter_list
+  (variadic_parameter_declaration) @parameter.inner)
+
+;; arguments
+(argument_list
+  (_) @parameter.inner)


### PR DESCRIPTION
This way we can use swap with Go.

There are some limitations in the query though, opening as a draft to see if I can get some input from others. With the current parser, the following function has only one parameter_declaration:

```go
func DoThing(i, j int) {}
```

This seems to be a problem with the Go parser? I'll keep playing around with it in the playground.