### PR TITLE
Fix #20: Add TSTextobjectSelect

### DIFF
--- a/autoload/nvim_treesitter_textobjects.vim
+++ b/autoload/nvim_treesitter_textobjects.vim
@@ -1,0 +1,3 @@
+function! nvim_treesitter_textobjects#available_textobjects(arglead, cmdline, cursorpos) abort
+    return join(luaeval("vim.tbl_map(function(o) return '@'..o end, require'nvim-treesitter.textobjects.shared'.available_textobjects())"), "\n")
+endfunction

--- a/lua/nvim-treesitter-textobjects.lua
+++ b/lua/nvim-treesitter-textobjects.lua
@@ -1,5 +1,6 @@
 local queries = require "nvim-treesitter.query"
 local configs = require "nvim-treesitter.configs"
+local utils = require "nvim-treesitter.utils"
 
 local M = {}
 
@@ -55,6 +56,9 @@ function M.init()
       }
     }
   }
+  for _, m in ipairs({'select', 'move', 'swap', 'lsp_interop'}) do
+    utils.setup_commands('textobjects.'..m, require ('nvim-treesitter.textobjects.'..m).commands)
+  end
 end
 
 return M

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -1,4 +1,5 @@
 local configs = require'nvim-treesitter.configs'
+local utils = require'nvim-treesitter.utils'
 local parsers = require'nvim-treesitter.parsers'
 local queries = require'nvim-treesitter.query'
 local api = vim.api
@@ -6,6 +7,7 @@ local M = {}
 
 function M.make_attach(normal_mode_functions, submodule)
   return function(bufnr, lang)
+    utils.setup_commands(submodule, M.commands)
     local config = configs.get_module("textobjects."..submodule)
     local lang = lang or parsers.get_buf_lang(bufnr)
 

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -1,5 +1,4 @@
 local configs = require'nvim-treesitter.configs'
-local utils = require'nvim-treesitter.utils'
 local parsers = require'nvim-treesitter.parsers'
 local queries = require'nvim-treesitter.query'
 local api = vim.api
@@ -7,7 +6,6 @@ local M = {}
 
 function M.make_attach(normal_mode_functions, submodule)
   return function(bufnr, lang)
-    utils.setup_commands(submodule, M.commands)
     local config = configs.get_module("textobjects."..submodule)
     local lang = lang or parsers.get_buf_lang(bufnr)
 

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -81,7 +81,7 @@ function M.peek_definition_code(textobject, lsp_request, context)
 end
 
 M.attach = attach.make_attach(normal_mode_functions, "lsp_interop")
-M.deattach = attach.make_detach(normal_mode_functions, "lsp_interop")
+M.detach = attach.make_detach(normal_mode_functions, "lsp_interop")
 M.commands = {}
 
 return M

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -82,6 +82,14 @@ end
 
 M.attach = attach.make_attach(normal_mode_functions, "lsp_interop")
 M.detach = attach.make_detach(normal_mode_functions, "lsp_interop")
-M.commands = {}
+M.commands = {
+  TSTextobjectPeekDefinitionCode = {
+    run = M.peek_definition_code,
+    args = {
+      "-nargs=+",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+}
 
 return M

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -82,5 +82,6 @@ end
 
 M.attach = attach.make_attach(normal_mode_functions, "lsp_interop")
 M.deattach = attach.make_detach(normal_mode_functions, "lsp_interop")
+M.commands = {}
 
 return M

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -45,12 +45,10 @@ local function move(query_string, forward, start, bufnr)
   ts_utils.goto_node(match and match.node, not start)
 end
 
--- luacheck: push ignore 631
 M.goto_next_start = function(query_string) move(query_string, 'forward', 'start') end
 M.goto_next_end = function(query_string) move(query_string, 'forward', not 'start') end
 M.goto_previous_start = function(query_string) move(query_string, not 'forward', 'start') end
 M.goto_previous_end = function(query_string) move(query_string, not 'forward', not 'start') end
--- luacheck: pop
 
 local normal_mode_functions = {"goto_next_start",
                                "goto_next_end",

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -58,7 +58,7 @@ local normal_mode_functions = {"goto_next_start",
                                "goto_previous_end"}
 
 M.attach = attach.make_attach(normal_mode_functions, "move")
-M.deattach = attach.make_detach(normal_mode_functions, "move")
+M.detach = attach.make_detach(normal_mode_functions, "move")
 M.commands = {}
 
 return M

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -59,5 +59,6 @@ local normal_mode_functions = {"goto_next_start",
 
 M.attach = attach.make_attach(normal_mode_functions, "move")
 M.deattach = attach.make_detach(normal_mode_functions, "move")
+M.commands = {}
 
 return M

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -59,6 +59,36 @@ local normal_mode_functions = {"goto_next_start",
 
 M.attach = attach.make_attach(normal_mode_functions, "move")
 M.detach = attach.make_detach(normal_mode_functions, "move")
-M.commands = {}
+
+M.commands = {
+  TSTextobjectGotoNextStart = {
+    run = M.goto_next_start,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+  TSTextobjectGotoNextEnd = {
+    run = M.goto_next_end,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+  TSTextobjectGotoPreviousStart = {
+    run = M.goto_previous_start,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+  TSTextobjectGotoPreviousEnd = {
+    run = M.goto_previous_end,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+}
 
 return M

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 local configs = require'nvim-treesitter.configs'
+local utils = require'nvim-treesitter.utils'
 local parsers = require'nvim-treesitter.parsers'
 local queries = require'nvim-treesitter.query'
 
@@ -32,6 +33,7 @@ function M.attach(bufnr, lang)
       api.nvim_buf_set_keymap(buf, "x", mapping, cmd, {silent = true, noremap = true })
     end
   end
+  utils.setup_commands('textobjects.select', M.commands)
 end
 
 function M.detach(bufnr)
@@ -51,5 +53,15 @@ function M.detach(bufnr)
     end
   end
 end
+
+M.commands = {
+  TSTextobjectSelect = {
+    run = M.select_textobject,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+}
 
 return M

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -1,6 +1,5 @@
 local api = vim.api
 local configs = require'nvim-treesitter.configs'
-local utils = require'nvim-treesitter.utils'
 local parsers = require'nvim-treesitter.parsers'
 local queries = require'nvim-treesitter.query'
 
@@ -33,7 +32,6 @@ function M.attach(bufnr, lang)
       api.nvim_buf_set_keymap(buf, "x", mapping, cmd, {silent = true, noremap = true })
     end
   end
-  utils.setup_commands('textobjects.select', M.commands)
 end
 
 function M.detach(bufnr)

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -7,6 +7,13 @@ local ts_utils = require'nvim-treesitter.ts_utils'
 
 local M = {}
 
+function M.available_textobjects(lang)
+  lang = lang or parsers.get_buf_lang()
+  local parsed_queries = queries.get_query(lang, 'textobjects')
+  local found_textobjects = parsed_queries and parsed_queries.captures or {}
+  return found_textobjects
+end
+
 function M.textobject_at_point(query_string, pos, bufnr)
   bufnr =  bufnr or vim.api.nvim_get_current_buf()
   local lang = parsers.get_buf_lang(bufnr)

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -31,6 +31,23 @@ local normal_mode_functions = {"swap_next",
 
 M.attach = attach.make_attach(normal_mode_functions, "swap")
 M.detach = attach.make_detach(normal_mode_functions, "swap")
-M.commands = {}
+
+M.commands = {
+  TSTextobjectSwapNext = {
+    run = M.swap_next,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+  TSTextobjectSwapPrevious = {
+    run = M.swap_previous,
+    args = {
+      "-nargs=1",
+      "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
+    },
+  },
+}
+
 
 return M

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -31,5 +31,6 @@ local normal_mode_functions = {"swap_next",
 
 M.attach = attach.make_attach(normal_mode_functions, "swap")
 M.deattach = attach.make_detach(normal_mode_functions, "swap")
+M.commands = {}
 
 return M

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -30,7 +30,7 @@ local normal_mode_functions = {"swap_next",
                                "swap_previous"}
 
 M.attach = attach.make_attach(normal_mode_functions, "swap")
-M.deattach = attach.make_detach(normal_mode_functions, "swap")
+M.detach = attach.make_detach(normal_mode_functions, "swap")
 M.commands = {}
 
 return M

--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -1,6 +1,6 @@
 -- Execute as `nvim --headless -c "luafile ./scripts/update-readme.lua"`
 local parsers = require 'nvim-treesitter.parsers'.get_parser_configs()
-local query = require 'nvim-treesitter.query'
+local shared = require 'nvim-treesitter.textobjects.shared'
 local sorted_parsers = {}
 
 for k, v in pairs(parsers) do
@@ -33,8 +33,7 @@ for _, v in ipairs(sorted_parsers) do
   generated_text = generated_text..'<tr>\n'
   generated_text = generated_text..'<td>'..lang..'</td>'
 
-  local parsed_queries = query.get_query(lang, 'textobjects')
-  local found_textobjects = parsed_queries and parsed_queries.captures or {}
+  local found_textobjects = shared.available_textobjects(lang)
 
   for _, o in ipairs(textobjects) do
     local found = vim.tbl_contains(found_textobjects, o:sub(2))


### PR DESCRIPTION
Add a command for selecting a textobject. More commands can be added by filling the command dictionaries of the submodules (this should be upstreamed to do on registration of every nvim-treesitter module).

@weilbith If you want more commands you can create a PR. You need to do the remap for select and operator pending mode (their was a comment why select is better than visual mode for this plugin).

![image](https://user-images.githubusercontent.com/7189118/98976748-051a8900-2518-11eb-972e-c5ce0994d225.png)

I guess it's more comfortable to set the mappings with a Lua plugin like
https://github.com/svermeulen/vimpeccable
```
vimp.nnoremap('<leader>hw', function()
  print('hello')
  print('world')
end)
```

or a own abbreviation
https://github.com/kyazdani42/dotfiles/blob/7a75655e387c0b4ec021f91d631027219b05b902/config/common/nvim/lua/init.lua#L69