### PR TITLE
Add @parameter.outer for Python/C/C++

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,14 @@ Each capture group can be declared as `inner` or `outer`.
 @call.outer
 @block.inner
 @block.outer
+@parameter.inner
+@parameter.outer
 ```
 
 Some nodes only have one type:
 
 ```
 @comment.outer
-@parameter.inner
 @statement.outer
 ```
 

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -54,8 +54,10 @@
 (preproc_else
   (_) @statement.outer)
 
-(parameter_list
-  (parameter_declaration) @parameter.inner)
+((parameter_list
+  (parameter_declaration) @parameter.inner . ","? @_end)
+ (make-range! "parameter.outer" @parameter.inner @_end))
 
-(argument_list
-  (_) @parameter.inner)
+((argument_list
+  (_) @parameter.inner . ","? @_end)
+ (make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -56,8 +56,8 @@
 
 ((parameter_list
   (parameter_declaration) @parameter.inner . ","? @_end)
- (make-range! "parameter.outer" @parameter.inner @_end))
+ (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((argument_list
   (_) @parameter.inner . ","? @_end)
- (make-range! "parameter.outer" @parameter.inner @_end))
+ (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -14,8 +14,9 @@
 (template_declaration
   (class_specifier) @class.outer) @class.outer.start
 
-(parameter_list
-  (optional_parameter_declaration) @parameter.inner)
+((parameter_list
+  (optional_parameter_declaration) @parameter.inner . ","? @_end)
+ (make-range! "parameter.outer" @parameter.inner @_end))
 
 (new_expression
   (argument_list) @call.inner) @call.outer

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -16,7 +16,7 @@
 
 ((parameter_list
   (optional_parameter_declaration) @parameter.inner . ","? @_end)
- (make-range! "parameter.outer" @parameter.inner @_end))
+ (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (new_expression
   (argument_list) @call.inner) @call.outer

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -34,23 +34,28 @@
 (call (_) @call.inner)
 
 ;; Parameters
-(parameters
-  [(identifier)
+((parameters
+  ([(identifier)
    (tuple)
    (typed_parameter)
    (default_parameter)
    (typed_default_parameter)
    (list_splat)
    (dictionary_splat)] @parameter.inner)
+   . ","? @_end)
+  (make-range! "parameter.outer" @parameter.inner @_end))
 
-(lambda_parameters
+((lambda_parameters
   [(identifier)
    (tuple)
    (typed_parameter)
    (default_parameter)
    (typed_default_parameter)
    (list_splat)
-   (dictionary_splat)] @parameter.inner)
+   (dictionary_splat)] @parameter.inner
+   . ","? @_end)
+  (make-range! "parameter.outer" @parameter.inner @_end))
 
 ; TODO: exclude comments using the future negate syntax from tree-sitter
-(argument_list (_) @parameter.inner)
+((argument_list (_) @parameter.inner . ","? @_end)
+ (make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -43,7 +43,7 @@
    (list_splat)
    (dictionary_splat)] @parameter.inner)
    . ","? @_end)
-  (make-range! "parameter.outer" @parameter.inner @_end))
+  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((lambda_parameters
   [(identifier)
@@ -54,8 +54,8 @@
    (list_splat)
    (dictionary_splat)] @parameter.inner
    . ","? @_end)
-  (make-range! "parameter.outer" @parameter.inner @_end))
+  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ; TODO: exclude comments using the future negate syntax from tree-sitter
 ((argument_list (_) @parameter.inner . ","? @_end)
- (make-range! "parameter.outer" @parameter.inner @_end))
+ (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -73,19 +73,25 @@
 (block (_) @statement.outer)
 
 ;; parameter
-(parameter) @parameter.inner
+(((parameter) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
-(tuple_pattern
-  (identifier) @parameter.inner) 
+((tuple_pattern
+  (identifier) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
-(tuple_struct_pattern
-  (identifier) @parameter.inner)
+((tuple_struct_pattern
+  (identifier) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
-(closure_parameters
-  (_) @parameter.inner)
+((closure_parameters
+  (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
-(arguments
-  (_) @parameter.inner)
+(((arguments
+  (_) @parameter.inner . ","? @_end))
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
-(meta_arguments
-  (_) @parameter.inner)
+((meta_arguments
+  (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 


### PR DESCRIPTION
Addresses: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/22

Requires: https://github.com/nvim-treesitter/nvim-treesitter/pull/657

It only works if your cursor is between the parameter or and the end character of the ",". I try to add @stsewd select next textobject soon to make it also work on spaces before the parameter