### PR TITLE
feat: Added queries for php

### DIFF
--- a/queries/php/textobjects.scm
+++ b/queries/php/textobjects.scm
@@ -1,0 +1,27 @@
+(function_definition 
+ body: (compound_statement) @function.inner) @function.outer
+
+(method_declaration
+  body: (compound_statement) @function.inner) @function.outer
+
+(class_declaration
+  body: (declaration_list) @class.inner) @class.outer
+
+(foreach_statement
+  body: (_)? @loop.inner) @loop.outer
+
+(while_statement
+  body: (_)? @loop.inner) @loop.outer
+
+(do_statement
+  body: (_)? @loop.inner) @loop.outer
+
+(switch_statement
+  body: (_)? @conditional.inner) @conditional.outer
+
+;;blocks
+(_ (switch_block) @block.inner) @block.outer
+
+;; parameters
+(formal_parameters
+  (simple_parameter) @parameter.inner)


### PR DESCRIPTION
I took the liberty to add some queries for php. I still new on the query language. I was not able to get `if_statement`
to work correctly at the moment. Also, I wanted the ability to select the body of a function, excluding the `{` and `}`.

I reviewed [Add @parameter.outer for Python/C/C++](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/23) PR but was not able the result that I am looking for. I am not sure if excluding the braces is feasibly in treesitter at the moment.

