### PR TITLE
Allow linewise selection

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -26,9 +26,7 @@ function M.detect_selection_mode(keymap_mode)
     local method = keymap_to_method[keymap_mode]
 
     if method == "visual" then
-      local t = { V = "linewise"}
-      t[ctrl_v] = "blockwise"
-      selection_mode = t[vim.fn.visualmode()]
+      selection_mode = vim.fn.visualmode()
     elseif method == "operator-pending" then
       local t = { noV = "linewise" }
       t["no" .. ctrl_v] = "blockwise"

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -16,24 +16,24 @@ function M.select_textobject(query_string, keymap_mode)
 end
 
 function M.detect_selection_mode(keymap_mode)
-    local selection_mode = "charwise"
-    local ctrl_v = vim.api.nvim_replace_termcodes("<C-v>", true, true, true)
+  local selection_mode = "charwise"
+  local ctrl_v = vim.api.nvim_replace_termcodes("<C-v>", true, true, true)
 
-    -- Update selection mode with different methods based on keymapping mode
-    local keymap_to_method = {
-      o = "operator-pending", s = "visual", v = "visual", x = "visual"
-    }
-    local method = keymap_to_method[keymap_mode]
+  -- Update selection mode with different methods based on keymapping mode
+  local keymap_to_method = {
+    o = "operator-pending", s = "visual", v = "visual", x = "visual"
+  }
+  local method = keymap_to_method[keymap_mode]
 
-    if method == "visual" then
-      selection_mode = vim.fn.visualmode()
-    elseif method == "operator-pending" then
-      local t = { noV = "linewise" }
-      t["no" .. ctrl_v] = "blockwise"
-      selection_mode = t[vim.fn.mode(1)]
-    end
+  if method == "visual" then
+    selection_mode = vim.fn.visualmode()
+  elseif method == "operator-pending" then
+    local t = { noV = "linewise" }
+    t["no" .. ctrl_v] = "blockwise"
+    selection_mode = t[vim.fn.mode(1)]
+  end
 
-    return selection_mode
+  return selection_mode
 end
 
 function M.attach(bufnr, lang)


### PR DESCRIPTION
Fixes #36.

Example Python code:
```python
def a():
    print("Hello")
    def b():
        print("World")
```

Now with cursor inside `print("World")` these are now possible:
- `Vaf` selects lines 3-4.
- `dVaf` deletes lines 3-4 (utilizing operator-pending linewise mode).

There is one minor corner case: with cursor inside `def b()` using `Vaf` selects all lines 1-4. This seems to be because of how `nvim-treesitter.ts_utils.update_selection()` works: it updates selection to the "nearest" textobject containing the _whole_ current selection. After using `V` on line `def b()`, selection goes outside of scope of `b()` and the whole enclosing function is selected (if there is no enclosing function and indent is due to outer class, for example, nothing is selected). Currently I don't see a way of fixing this without updating `nvim-treesitter.ts_utils.update_selection()` directly.