### PR TITLE
Add super basic vue support

### DIFF
--- a/queries/vue/textobjects.scm
+++ b/queries/vue/textobjects.scm
@@ -1,0 +1,6 @@
+(element) @function.outer
+[
+  (attribute)
+  (directive_attribute)
+] @call.outer
+(attribute_value) @parameter.outer


### PR DESCRIPTION
Adds textobjects for attributes and Vue directives

Testable with this file:

```
<template>
  <SomeComponent my-attribute :my-directive="false" @my-event="method"/>
  <div class="abcd">hello</div>
</template>
```

If I bind move_next to eg. `<f2>`, I notice that if I write `c<f2>` nothing happens. I expected it'll work the same as `cw`. Did I implement something wrong?