### PR TITLE
Add textobjects.select.lookahead option to select the next textobject

### DIFF
--- a/doc/nvim-treesitter-textobjects.txt
+++ b/doc/nvim-treesitter-textobjects.txt
@@ -13,6 +13,7 @@ Query files: `textobjects.scm`.
 Supported options:
 - enable: `true` or `false`.
 - disable: list of languages.
+- lookahead: `true` or `false`, whether or not to look ahead for the textobject
 - keymaps: map of keymaps to a tree-sitter query
   (`(function_definition) @function`) or capture group (`@function.inner`).
 

--- a/lua/nvim-treesitter-textobjects.lua
+++ b/lua/nvim-treesitter-textobjects.lua
@@ -27,6 +27,7 @@ function M.init()
         is_supported = function(lang)
           return M.has_textobjects(lang) or has_some_textobject_mapping(lang)
         end,
+        lookahead = false,
         keymaps = {}
       },
       move = {

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -9,7 +9,8 @@ local ts_utils = require'nvim-treesitter.ts_utils'
 local M = {}
 
 function M.select_textobject(query_string, keymap_mode)
-  local bufnr, textobject = shared.textobject_at_point(query_string)
+  local lookahead = configs.get_module("textobjects.select").lookahead
+  local bufnr, textobject = shared.textobject_at_point(query_string, nil, nil, lookahead)
   if textobject then
     ts_utils.update_selection(bufnr, textobject, M.detect_selection_mode(keymap_mode))
   end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -10,7 +10,7 @@ local M = {}
 
 function M.select_textobject(query_string, keymap_mode)
   local lookahead = configs.get_module("textobjects.select").lookahead
-  local bufnr, textobject = shared.textobject_at_point(query_string, nil, nil, lookahead)
+  local bufnr, textobject = shared.textobject_at_point(query_string, nil, nil, {lookahead = lookahead})
   if textobject then
     ts_utils.update_selection(bufnr, textobject, M.detect_selection_mode(keymap_mode))
   end

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -13,7 +13,8 @@ function M.available_textobjects(lang)
   return found_textobjects
 end
 
-function M.textobject_at_point(query_string, pos, bufnr, lookahead)
+function M.textobject_at_point(query_string, pos, bufnr, opts)
+  opts = opts or {}
   bufnr =  bufnr or vim.api.nvim_get_current_buf()
   local lang = parsers.get_buf_lang(bufnr)
   if not lang then return end
@@ -69,7 +70,7 @@ function M.textobject_at_point(query_string, pos, bufnr, lookahead)
           end
         end
       end
-    elseif lookahead then
+    elseif opts.lookahead then
       local start_line, start_col, start_byte = m.node:start()
       if start_line > row or start_line == row and start_col > col then
         local length = ts_utils.node_length(m.node)


### PR DESCRIPTION
Haven't added docs, if you think this functionality is in scope of the plugin let me know and I can add docs.

This allows `select` to look ahead in the syntax tree if it cannot find a match with the cursor position in it. E.g.

```lua
local x = 'hello' -- <- your cursor is here and you press `vaf`
function foo()  -- ----
  print('foo')  --     | <- this would be selected
end             -- ----
```

Sample Config:

```lua
treesitter.setup {
    textobjects = {
        select = {
            enable = true,
            lookahead = true,
            keymaps = {
                ['af'] = '@function.outer',
            }
        },
    }
}
```