### PR TITLE
Add initializer_list to @parameter for cpp queries

### DIFF
--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -18,5 +18,9 @@
   (optional_parameter_declaration) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
+((initializer_list
+  (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
 (new_expression
   (argument_list) @call.inner) @call.outer


### PR DESCRIPTION
For cpp files `@parameter` does not support `initializer_list`. This adds support for `initializer_list`. 