### PR TITLE
add lookahead readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ require'nvim-treesitter.configs'.setup {
   textobjects = {
     select = {
       enable = true,
+
+      -- Automatically jump forward to textobj, similar to targets.vim 
+      lookahead = true,
+
       keymaps = {
         -- You can use the capture groups defined in textobjects.scm
         ["af"] = "@function.outer",


### PR DESCRIPTION
```
-- Automatically jump forward to textobj, similar to targets.vim 
lookahead = true,
```