### PR TITLE
fix typescript optional params

### DIFF
--- a/queries/typescript/textobjects.scm
+++ b/queries/typescript/textobjects.scm
@@ -45,4 +45,4 @@
 
 ;; parameters
 (formal_parameters
-  (required_parameter) @parameter.inner)
+  (_) @parameter.inner)


### PR DESCRIPTION
The current type def does not apply to "optional parameters", like "c" below.

```
function fn(a, b, c?) {
}

Treesitter:
function_declaration [78, 0] - [79, 1]
  name: identifier [78, 9] - [78, 11]
  parameters: formal_parameters [78, 11] - [78, 21]
    required_parameter [78, 12] - [78, 13]
      identifier [78, 12] - [78, 13]
    required_parameter [78, 15] - [78, 16]
      identifier [78, 15] - [78, 16]
    optional_parameter [78, 18] - [78, 20]
      identifier [78, 18] - [78, 19]
  body: statement_block [78, 22] - [79, 1]

```