### PR TITLE
Make parameter.outer delete the preceeding comma in python, dart, rust, c/c++, and some other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-```
-parameter.outer
-
-queries/*/textobjects.scm
-```
-
 # nvim-treesitter-textobjects
 
 Create your own textobjects using tree-sitter queries!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+```
+parameter.outer
+
+queries/*/textobjects.scm
+```
+
 # nvim-treesitter-textobjects
 
 Create your own textobjects using tree-sitter queries!

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -64,12 +64,12 @@
   "," @_start . (parameter_declaration) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((parameter_list
-  "(" . (parameter_declaration) @parameter.inner . "," @_end)
+  . (parameter_declaration) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((argument_list
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((argument_list
-  "(" . (_) @parameter.inner . "," @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -64,12 +64,12 @@
   "," @_start . (parameter_declaration) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((parameter_list
-  (parameter_declaration) @parameter.inner . "," @_end)
+  "(" . (parameter_declaration) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((argument_list
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((argument_list
-  (_) @parameter.inner . "," @_end)
+  "(" . (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -61,9 +61,15 @@
   (_) @statement.outer)
 
 ((parameter_list
-  (parameter_declaration) @parameter.inner . ","? @_end)
+  "," @_start . (parameter_declaration) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((parameter_list
+  (parameter_declaration) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((argument_list
-  (_) @parameter.inner . ","? @_end)
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((argument_list
+  (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -18,12 +18,39 @@
 (template_declaration
   (class_specifier) @class.outer) @class.outer.start
 
+((lambda_capture_specifier
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((lambda_capture_specifier
+  (_) @parameter.inner . "," @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
+((template_argument_list
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((template_argument_list
+  (_) @parameter.inner . "," @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
+((template_parameter_list
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((template_parameter_list
+  (_) @parameter.inner . "," @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
 ((parameter_list
-  (optional_parameter_declaration) @parameter.inner . ","? @_end)
+  "," @_start . (optional_parameter_declaration) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((parameter_list
+  (optional_parameter_declaration) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((initializer_list
-  (_) @parameter.inner . ","? @_end)
+  "," @_start . (_) @parameter.inner  @_end)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((initializer_list
+  (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (new_expression

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -22,35 +22,35 @@
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((lambda_capture_specifier
-  (_) @parameter.inner . "," @_end)
+  "[" . (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((template_argument_list
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((template_argument_list
-  (_) @parameter.inner . "," @_end)
+  "<" . (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((template_parameter_list
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((template_parameter_list
-  (_) @parameter.inner . "," @_end)
+  "<" . (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((parameter_list
   "," @_start . (optional_parameter_declaration) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((parameter_list
-  (optional_parameter_declaration) @parameter.inner . "," @_end)
+  "(" . (optional_parameter_declaration) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((initializer_list
   "," @_start . (_) @parameter.inner  @_end)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((initializer_list
-  (_) @parameter.inner . "," @_end)
+  "{" . (_) @parameter.inner . "," @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (new_expression

--- a/queries/cpp/textobjects.scm
+++ b/queries/cpp/textobjects.scm
@@ -22,35 +22,35 @@
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((lambda_capture_specifier
-  "[" . (_) @parameter.inner . "," @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((template_argument_list
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((template_argument_list
-  "<" . (_) @parameter.inner . "," @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((template_parameter_list
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((template_parameter_list
-  "<" . (_) @parameter.inner . "," @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((parameter_list
   "," @_start . (optional_parameter_declaration) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((parameter_list
-  "(" . (optional_parameter_declaration) @parameter.inner . "," @_end)
+  . (optional_parameter_declaration) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ((initializer_list
   "," @_start . (_) @parameter.inner  @_end)
  (#make-range! "parameter.outer" @_start @parameter.inner))
 ((initializer_list
-  "{" . (_) @parameter.inner . "," @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (new_expression

--- a/queries/dart/textobjects.scm
+++ b/queries/dart/textobjects.scm
@@ -21,20 +21,26 @@
 (type_alias (function_type)? @function.inner) @function.outer
 
 ; parameter
+[
+  (formal_parameter)
+  (normal_parameter_type)
+  (type_parameter)
+] @parameter.inner
 (
 "," @_start . [
   (formal_parameter)
   (normal_parameter_type)
   (type_parameter)
- ] @parameter.inner
- (#make-range! "parameter.outer" @_start @parameter.inner))
+ ] @_par
+ (#make-range! "parameter.outer" @_start @_par))
 (
- . [
+ [
   (formal_parameter)
   (normal_parameter_type)
   (type_parameter)
- ] @parameter.inner . ","? @_end 
- (#make-range! "parameter.outer" @parameter.inner @_end))
+ ] @_par . "," @_end 
+ (#make-range! "parameter.outer" @_par @_end))
+
 ;; TODO: (_)* not supported yet -> for now this works correctly only with simple arguments 
 ((arguments
   . (_) @parameter.inner . ","? @_end)

--- a/queries/dart/textobjects.scm
+++ b/queries/dart/textobjects.scm
@@ -28,19 +28,20 @@
   (type_parameter)
  ] @parameter.inner
  (#make-range! "parameter.outer" @_start @parameter.inner))
-([
+(
+ . [
   (formal_parameter)
   (normal_parameter_type)
   (type_parameter)
- ] @parameter.inner . "," @_end 
+ ] @parameter.inner . ","? @_end 
  (#make-range! "parameter.outer" @parameter.inner @_end))
 ;; TODO: (_)* not supported yet -> for now this works correctly only with simple arguments 
 ((arguments
-  (_) @parameter.inner . "," @_end)
- (#make-range! "parameter.outer" @_start @parameter.inner))
+  . (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
 ((arguments
   "," @_start . (_) @parameter.inner)
- (#make-range! "parameter.outer" @parameter.inner @_end))
+ (#make-range! "parameter.outer" @_start @parameter.inner))
 
 ; call
 (expression_statement

--- a/queries/dart/textobjects.scm
+++ b/queries/dart/textobjects.scm
@@ -21,15 +21,25 @@
 (type_alias (function_type)? @function.inner) @function.outer
 
 ; parameter
+(
+"," @_start . [
+  (formal_parameter)
+  (normal_parameter_type)
+  (type_parameter)
+ ] @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
 ([
   (formal_parameter)
   (normal_parameter_type)
   (type_parameter)
- ] @parameter.inner . ","? @_end 
+ ] @parameter.inner . "," @_end 
  (#make-range! "parameter.outer" @parameter.inner @_end))
 ;; TODO: (_)* not supported yet -> for now this works correctly only with simple arguments 
 ((arguments
-  (_) @parameter.inner . ","? @_end)
+  (_) @parameter.inner . "," @_end)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((arguments
+  "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ; call

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -45,8 +45,6 @@
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -57,14 +55,13 @@
 (
   (
   parameters
+    "(" @justforfun .
     [
       (identifier)
       (tuple)
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -83,8 +80,6 @@
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -101,8 +96,6 @@
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -121,8 +114,6 @@
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -133,14 +124,13 @@
 (
   (
   tuple
+    "(" .
     [
       (identifier)
       (tuple)
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -159,8 +149,6 @@
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -171,14 +159,13 @@
 (
   (
   list
+    "[" .
     [
       (identifier)
       (tuple)
       (typed_parameter)
       (default_parameter)
       (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
@@ -188,5 +175,3 @@
 )
 
 ; TODO: exclude comments using the future negate syntax from tree-sitter
-((argument_list (_) @parameter.inner . ","? @_end)
- (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -174,4 +174,24 @@
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
 
+(
+  (
+  dictionary
+    "{" .
+    (pair) @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
+
+(
+  (
+  dictionary
+    "," @_start . 
+    (pair) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
+)
+
 ; TODO: exclude comments using the future negate syntax from tree-sitter

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -34,27 +34,81 @@
 (call (_) @call.inner)
 
 ;; Parameters
-((parameters
-  ([(identifier)
-   (tuple)
-   (typed_parameter)
-   (default_parameter)
-   (typed_default_parameter)
-   (list_splat)
-   (dictionary_splat)] @parameter.inner)
-   . ","? @_end)
-  (#make-range! "parameter.outer" @parameter.inner @_end))
+(
+  (
+  parameters
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      ; (dictionary_splat_pattern)
+      ; (list_splat_pattern)
+    ] @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
 
-((lambda_parameters
-  [(identifier)
-   (tuple)
-   (typed_parameter)
-   (default_parameter)
-   (typed_default_parameter)
-   (list_splat)
-   (dictionary_splat)] @parameter.inner
-   . ","? @_end)
-  (#make-range! "parameter.outer" @parameter.inner @_end))
+(
+  (
+  lambda_parameters
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      ; (dictionary_splat_pattern)
+      ; (list_splat_pattern)
+    ] @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
+(
+  (
+  parameters
+    "," @_start .
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      ; (dictionary_splat_pattern)
+      ; (list_splat_pattern)
+    ] @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
+)
+
+(
+  (
+  lambda_parameters
+    "," @_start .
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      ; (dictionary_splat_pattern)
+      ; (list_splat_pattern)
+    ] @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
+)
 
 ; TODO: exclude comments using the future negate syntax from tree-sitter
 ((argument_list (_) @parameter.inner . ","? @_end)

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -87,7 +87,6 @@
       ; (dictionary_splat_pattern)
       ; (list_splat_pattern)
     ] @parameter.inner
-    . ")"
   )
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )
@@ -107,7 +106,6 @@
       ; (dictionary_splat_pattern)
       ; (list_splat_pattern)
     ] @parameter.inner
-    . ")"
   )
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -47,27 +47,8 @@
       (typed_default_parameter)
       (list_splat)
       (dictionary_splat)
-      ; (dictionary_splat_pattern)
-      ; (list_splat_pattern)
-    ] @parameter.inner
-  )
-  (#make-range! "parameter.outer" @_start @parameter.inner)
-)
-
-(
-  (
-  lambda_parameters
-    "," @_start .
-    [
-      (identifier)
-      (tuple)
-      (typed_parameter)
-      (default_parameter)
-      (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
-      ; (dictionary_splat_pattern)
-      ; (list_splat_pattern)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
     ] @parameter.inner
   )
   (#make-range! "parameter.outer" @_start @parameter.inner)
@@ -84,12 +65,31 @@
       (typed_default_parameter)
       (list_splat)
       (dictionary_splat)
-      ; (dictionary_splat_pattern)
-      ; (list_splat_pattern)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
     ] @parameter.inner
     . "," @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
+(
+  (
+  lambda_parameters
+    "," @_start .
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
+    ] @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
 )
 
 (
@@ -103,13 +103,90 @@
       (typed_default_parameter)
       (list_splat)
       (dictionary_splat)
-      ; (dictionary_splat_pattern)
-      ; (list_splat_pattern)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
     ] @parameter.inner
     . "," @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
+
+(
+  (
+  tuple
+    "," @_start .
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
+    ] @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
+)
+
+(
+  (
+  tuple
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
+    ] @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
+(
+  (
+  list
+    "," @_start .
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
+    ] @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
+)
+
+(
+  (
+  list
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      (dictionary_splat_pattern)
+      (list_splat_pattern)
+    ] @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
 ; TODO: exclude comments using the future negate syntax from tree-sitter
 ((argument_list (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -35,9 +35,7 @@
 
 ;; Parameters
 
-(
-  (
-  parameters
+((parameters
     "," @_start .
     [
       (identifier)
@@ -49,12 +47,9 @@
       (list_splat_pattern)
     ] @parameter.inner
   )
-  (#make-range! "parameter.outer" @_start @parameter.inner)
-)
+  (#make-range! "parameter.outer" @_start @parameter.inner))
 
-(
-  (
-  parameters
+((parameters
     . [
       (identifier)
       (tuple)
@@ -69,9 +64,7 @@
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
 
-(
-  (
-  lambda_parameters
+((lambda_parameters
     "," @_start .
     [
       (identifier)
@@ -83,12 +76,9 @@
       (list_splat_pattern)
     ] @parameter.inner
   )
-  (#make-range! "parameter.outer" @_start @parameter.inner)
-)
+  (#make-range! "parameter.outer" @_start @parameter.inner))
 
-(
-  (
-  lambda_parameters
+((lambda_parameters
     . [
       (identifier)
       (tuple)
@@ -100,12 +90,9 @@
     ] @parameter.inner
     . ","? @_end
   )
-  (#make-range! "parameter.outer" @parameter.inner @_end)
-)
+  (#make-range! "parameter.outer" @parameter.inner @_end))
 
-(
-  (
-  tuple
+((tuple
     "," @_start .
     [
       (identifier)
@@ -120,9 +107,7 @@
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )
 
-(
-  (
-  tuple
+((tuple
     "(" .
     [
       (identifier)
@@ -138,9 +123,7 @@
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
 
-(
-  (
-  list
+((list
     "," @_start .
     [
       (identifier)
@@ -155,9 +138,7 @@
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )
 
-(
-  (
-  list
+((list
     . [
       (identifier)
       (tuple)
@@ -169,43 +150,30 @@
     ] @parameter.inner
     . ","? @_end
   )
-  (#make-range! "parameter.outer" @parameter.inner @_end)
-)
+  (#make-range! "parameter.outer" @parameter.inner @_end))
 
-(
-  (
-  dictionary
+((dictionary
     . (pair) @parameter.inner
     . ","? @_end
   )
-  (#make-range! "parameter.outer" @parameter.inner @_end)
-)
+  (#make-range! "parameter.outer" @parameter.inner @_end))
 
-(
-  (
-  dictionary
+((dictionary
     "," @_start . 
     (pair) @parameter.inner
   )
-  (#make-range! "parameter.outer" @_start @parameter.inner)
-)
+  (#make-range! "parameter.outer" @_start @parameter.inner))
 
-(
-  (
-  argument_list
+((argument_list
     . (_) @parameter.inner
     . ","? @_end
   )
-  (#make-range! "parameter.outer" @parameter.inner @_end)
-)
+  (#make-range! "parameter.outer" @parameter.inner @_end))
 
-(
-  (
-  argument_list
+((argument_list
     "," @_start .
     (_) @parameter.inner
   )
-  (#make-range! "parameter.outer" @_start @parameter.inner)
-)
+  (#make-range! "parameter.outer" @_start @parameter.inner))
 
 ; TODO: exclude comments using the future negate syntax from tree-sitter

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -87,6 +87,7 @@
       ; (dictionary_splat_pattern)
       ; (list_splat_pattern)
     ] @parameter.inner
+    . ")"
   )
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )
@@ -106,6 +107,7 @@
       ; (dictionary_splat_pattern)
       ; (list_splat_pattern)
     ] @parameter.inner
+    . ")"
   )
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -65,7 +65,7 @@
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
-    . "," @_end
+    . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
@@ -99,7 +99,7 @@
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
-    . "," @_end
+    . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
@@ -134,7 +134,7 @@
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
-    . "," @_end
+    . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
@@ -169,7 +169,7 @@
       (dictionary_splat_pattern)
       (list_splat_pattern)
     ] @parameter.inner
-    . "," @_end
+    . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
@@ -179,17 +179,35 @@
   dictionary
     "{" .
     (pair) @parameter.inner
-    . "," @_end
+    . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
 )
-
 
 (
   (
   dictionary
     "," @_start . 
     (pair) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner)
+)
+
+(
+  (
+  argument_list
+    "(" .
+    (_) @parameter.inner
+    . ","? @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
+(
+  (
+  argument_list
+    "," @_start .
+    (_) @parameter.inner
   )
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -55,8 +55,7 @@
 (
   (
   parameters
-    "(" @justforfun .
-    [
+    . [
       (identifier)
       (tuple)
       (typed_parameter)
@@ -90,7 +89,7 @@
 (
   (
   lambda_parameters
-    [
+    . [
       (identifier)
       (tuple)
       (typed_parameter)
@@ -159,8 +158,7 @@
 (
   (
   list
-    "[" .
-    [
+    . [
       (identifier)
       (tuple)
       (typed_parameter)
@@ -177,8 +175,7 @@
 (
   (
   dictionary
-    "{" .
-    (pair) @parameter.inner
+    . (pair) @parameter.inner
     . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)
@@ -196,8 +193,7 @@
 (
   (
   argument_list
-    "(" .
-    (_) @parameter.inner
+    . (_) @parameter.inner
     . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end)

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -34,43 +34,6 @@
 (call (_) @call.inner)
 
 ;; Parameters
-(
-  (
-  parameters
-    [
-      (identifier)
-      (tuple)
-      (typed_parameter)
-      (default_parameter)
-      (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
-      ; (dictionary_splat_pattern)
-      ; (list_splat_pattern)
-    ] @parameter.inner
-    . "," @_end
-  )
-  (#make-range! "parameter.outer" @parameter.inner @_end)
-)
-
-(
-  (
-  lambda_parameters
-    [
-      (identifier)
-      (tuple)
-      (typed_parameter)
-      (default_parameter)
-      (typed_default_parameter)
-      (list_splat)
-      (dictionary_splat)
-      ; (dictionary_splat_pattern)
-      ; (list_splat_pattern)
-    ] @parameter.inner
-    . "," @_end
-  )
-  (#make-range! "parameter.outer" @parameter.inner @_end)
-)
 
 (
   (
@@ -110,6 +73,43 @@
   (#make-range! "parameter.outer" @_start @parameter.inner)
 )
 
+(
+  (
+  parameters
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      ; (dictionary_splat_pattern)
+      ; (list_splat_pattern)
+    ] @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
+
+(
+  (
+  lambda_parameters
+    [
+      (identifier)
+      (tuple)
+      (typed_parameter)
+      (default_parameter)
+      (typed_default_parameter)
+      (list_splat)
+      (dictionary_splat)
+      ; (dictionary_splat_pattern)
+      ; (list_splat_pattern)
+    ] @parameter.inner
+    . "," @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end)
+)
 ; TODO: exclude comments using the future negate syntax from tree-sitter
 ((argument_list (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -74,25 +74,43 @@
 (block (_) @statement.outer)
 
 ;; parameter
+
+(("," @_start . (parameter) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
 (((parameter) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((tuple_pattern
+  "," @_start . (identifier) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
+((tuple_pattern 
   (identifier) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((tuple_struct_pattern
+  "," @_start . (identifier) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
+((tuple_struct_pattern 
   (identifier) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((closure_parameters
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
+((closure_parameters 
   (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
-(((arguments
-  (_) @parameter.inner . ","? @_end))
+((arguments
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
+((arguments 
+  (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
+((meta_arguments
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((meta_arguments
   (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -77,40 +77,41 @@
 
 (("," @_start . (parameter) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
-(((parameter) @parameter.inner . ","? @_end)
+((parameters . (parameter) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((tuple_pattern
   "," @_start . (identifier) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((tuple_pattern 
-  (identifier) @parameter.inner . ","? @_end)
+  . (identifier) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((tuple_struct_pattern
   "," @_start . (identifier) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((tuple_struct_pattern 
-  (identifier) @parameter.inner . ","? @_end)
+  . (identifier) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((closure_parameters
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((closure_parameters 
-  (_) @parameter.inner . ","? @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((arguments
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((arguments 
-  (_) @parameter.inner . ","? @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((meta_arguments
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((meta_arguments
-  (_) @parameter.inner . ","? @_end)
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
+

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -75,9 +75,18 @@
 
 ;; parameter
 
-(("," @_start . (parameter) @parameter.inner)
+((parameters 
+  "," @_start . (parameter) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
-((parameters . (parameter) @parameter.inner . ","? @_end)
+((parameters
+  . (parameter) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
+
+((type_parameters
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
+((type_parameters 
+  . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((tuple_pattern
@@ -105,6 +114,13 @@
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
 ((arguments 
+  . (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end)) 
+
+((type_arguments
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner)) 
+((type_arguments 
   . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end)) 
 


### PR DESCRIPTION
Fixes #85

This will actually delete the preceeding comma for all arguments expect the first parameter. This leaves the argument list better formatted in most cases (by not leaving an extra space as it used too). The first parameter will still leave a space, which we don't know how to fix currently

This PR also makes parameter.outer delete entries from tuples, list and dictionaries in python.
Also, It makes parameter.* cover template parameter/argument lists and lambda capture lists in c++.
(related to #86)

We may open some more pull requests for correcting parameter handling in other languages as we get time