### PR TITLE
Added Julia inner text objects

### DIFF
--- a/queries/julia/textobjects.scm
+++ b/queries/julia/textobjects.scm
@@ -1,21 +1,104 @@
-(compound_expression) @block.outer    ; begin blocks
-(let_statement)       @block.outer
+; Blocks
+((compound_expression
+  . (_)? @_start
+  (_) @_end .)
+(#make-range! "block.inner" @_start @_end)) @block.outer
+((let_statement
+  . (_)? @_start
+  (_) @_end .)
+(#make-range! "block.inner" @_start @_end)) @block.outer
 
-(struct_definition) @class.outer    ; not classes, but close enough
-(call_expression) @call.outer
+; Calls
+(call_expression
+  (argument_list) @call.inner) @call.outer
 
-(comment) @comment.outer
+; Objects (class)
+((struct_definition
+  name: (_)
+  . (_)? @_start
+  (_) @_end .
+  "end"
+)(#make-range! "class.inner" @_start @_end)) @class.outer
 
-(if_statement) @conditional.outer
+((struct_definition
+  name: (_) type_parameters: (_)
+  . (_)? @_start
+  (_) @_end .
+  "end"
+)(#make-range! "class.inner" @_start @_end)) @class.outer
 
-(function_definition) @function.outer
-(assignment_expression
-  (call_expression) (_)) @function.outer    ; math functions
-(function_expression)    @function.outer    ; lambdas
-(macro_definition)       @function.outer
+; Comments
+[(comment) (triple_string)]@comment.outer
 
-(for_statement)    @loop.outer
-(while_statement)  @loop.outer
+; Conditionals
+((if_statement condition: (_)
+    . (_)? @_start
+    .
+    (_) @_end .
+    ["end" (elseif_clause) (else_clause)])
+(#make-range! "conditional.inner" @_start @_end)) @conditional.outer
+((elseif_clause condition: (_)
+  . (_)? @_start
+  (_) @_end .)
+(#make-range! "conditional.inner" @_start @_end))
+((else_clause
+  . (_)? @_start
+  (_) @_end .)
+(#make-range! "conditional.inner" @_start @_end))
 
-(argument_list) @parameter.outer
-(parameter_list) @parameter.outer
+; Functions
+(assignment_expression 
+  (call_expression (_)) 
+  (_) @function.inner) @function.outer
+
+(function_expression 
+  [ (identifier) (parameter_list) ] 
+  "->" 
+  (_) @function.inner) @function.outer
+
+((macro_definition
+  name: (_) parameters: (_)
+  . (_)? @_start
+  (_) @_end .
+  "end"
+)(#make-range! "function.inner" @_start @_end)) @function.outer
+
+((function_definition
+  name: (_) parameters: (_)
+  . (_)? @_start
+  (_) @_end .
+  "end"
+)(#make-range! "function.inner" @_start @_end)) @function.outer
+
+; Loops
+(for_statement
+ . (_)? @_start
+ (_) @_end .
+ (#make-range! "loop.inner" @_start @_end)
+  "end") @loop.outer
+(while_statement
+ . (_)? @_start
+ (_) @_end .
+ (#make-range! "loop.inner" @_start @_end)
+  "end") @loop.outer
+
+; Parameters
+((argument_list
+    "," @_start .
+    (_) @parameter.inner)
+(#make-range! "parameter.outer" @_start @parameter.inner))
+
+((argument_list
+    (_) @parameter.inner
+    . "," @_end)
+(#make-range! "parameter.outer" @parameter.inner @_end))
+
+((parameter_list
+    "," @_start .
+    (_) @parameter.inner)
+(#make-range! "parameter.outer" @_start @parameter.inner))
+
+((parameter_list
+    (_) @parameter.inner
+    . [","] @_end)
+(#make-range! "parameter.outer" @parameter.inner @_end))


### PR DESCRIPTION
This should add inner text objects for julia language. I'm still learning treesitter queries, so some of them might not be the most elegant solution, but I have tested them all and they seem to work with every edge case I could think of.

The one thing I couldn't figure out is how to get the let_statement inner.block to not also include the variable declarations at the start of the block. Best I could manage was to make it not include the first variable declaration, but I thought that it was better to have it consistent but wrong so I left it as including all of them.