### PR TITLE
Add more ruby text objects

### DIFF
--- a/queries/ruby/textobjects.scm
+++ b/queries/ruby/textobjects.scm
@@ -8,9 +8,15 @@
 
 ;; classes
 [
+  ;; match against classes with and without parrents
   (class
     name: (constant)
     superclass: (_)
+    (_) @class.inner)
+
+  (class
+    name: (constant)
+    !superclass
     (_) @class.inner)
 
   (module

--- a/queries/ruby/textobjects.scm
+++ b/queries/ruby/textobjects.scm
@@ -1,28 +1,80 @@
-[
-  (method)
-  (singleton_method)
-] @function.outer
+;; blocks
+(call
+  block: (_) @block.inner) @block.outer
 
+;; calls
+(call
+  method: (_) @call.inner ) @call.outer
+
+;; classes
 [
-  (class)
-  (module)
+  (class
+    name: (constant)
+    superclass: (_)
+    (_) @class.inner)
+
+  (module
+    name: (constant)
+    (_) @class.inner)
 ] @class.outer
 
-[
-  (if)
-  (unless)
-  (case)
-] @conditional.outer
+;; comments
+(comment) @comment.outer
 
+;; conditionals
 [
-  (while)
-  (while_modifier)
-  (until)
-  (until_modifier)
-  (for)
+  (if
+   consequence: (_) @conditional.inner
+   alternative: (_) @conditional.inner)
+
+  (if_modifier
+    condition: (_) @conditional.inner)
+
+  (until_modifier
+     condition: (_) @conditional.inner)
+
+  (unless
+   consequence: (_) @conditional.inner
+   alternative: (_) @conditional.inner)
+
+  (case
+    value: (_)
+    (_) @conditional.inner)
+]  @conditional.outer
+
+;; functions
+[
+  (method
+    (identifier)
+    (_) @function.inner)
+
+  (singleton_method
+    (identifier)
+    (_) @function.inner)
+] @function.outer
+
+;; loops
+[
+  (while
+    body: (_) @loop.inner)
+
+  (while_modifier
+    condition: (_) @loop.inner)
+
+  (until
+    body: (_) @loop.inner)
+
+  (until_modifier
+    condition: (_) @loop.inner)
+
+  (for
+    body: (_) @loop.inner)
 ] @loop.outer
 
-(call) @call.outer
+;; parameters
 
-(call
-  block: (_)) @block.outer
+[
+ (block_parameters (_) @parameter.inner)
+
+ (method_parameters (_) @parameters.inner )
+] @parameters.outer


### PR DESCRIPTION
I have added all the inner variants of the supplied text objects as well
as 
- adding modifier variants of conditionals and loops, 
- comments and
- parameters support

I have tried keep these query's efficient but there may be room for improvement
[](https://github.com/hlissner/doom-emacs/pull/5401)