### PR TITLE
Adds fish shell textobjects

### DIFF
--- a/queries/fish/textobjects.scm
+++ b/queries/fish/textobjects.scm
@@ -1,0 +1,16 @@
+(function_definition) @function.outer
+
+(for_statement
+  (_) @loop.inner) @loop.outer
+
+(while_statement
+  condition: (command)
+  (command) @loop.inner) @loop.outer
+
+(if_statement
+  (command) @conditional.inner) @conditional.outer
+
+(switch_statement 
+  (_) @conditional.inner) @conditional.outer
+
+(comment) @comment.outer


### PR DESCRIPTION
The objects are limit due to choices in the grammar and the lack of ability to select groups of sibling nodes of the same type.