### PR TITLE
Fix some ruby text objects

### DIFF
--- a/queries/ruby/textobjects.scm
+++ b/queries/ruby/textobjects.scm
@@ -1,27 +1,139 @@
-;; blocks
-(call
-  block: (_) @block.inner) @block.outer
+;; @functions
+(
+  [
+    (method
+      . name: (identifier) 
+      !parameters 
+      . (_) @_start (_) @_end .)
+
+    (method
+      . name: (identifier) 
+      . parameters: (method_parameters) 
+      . (_) @_start (_) @_end .)
+
+    (singleton_method
+      . object: (_)
+      . name: (identifier) 
+      !parameters 
+      . (_) @_start (_) @_end .)
+
+    (singleton_method
+      . object: (_)
+      . name: (identifier) 
+      . parameters: (method_parameters) 
+      . (_) @_start (_) @_end .)
+  ] @function.outer
+   (#make-range! "function.inner" @_start @_end))
+
+[
+  (method
+    . name: (identifier) 
+    !parameters 
+    . (_) @function.inner .)
+
+  (method
+    . name: (identifier) 
+    . parameters: (method_parameters) 
+    . (_) @function.inner .)
+
+  (singleton_method
+    . object: (_)
+    . name: (identifier) 
+    !parameters 
+    . (_) @function.inner .)
+
+  (singleton_method
+    . object: (_)
+    . name: (identifier) 
+    . parameters: (method_parameters) 
+    . (_) @function.inner .)
+] @function.outer
+
+;; @blocks
+(
+  [
+    (call
+      block: (_
+        !parameters
+        . (_) @_start (_) @_end .)
+      )
+
+    (call
+      block: (_
+        . parameters: (block_parameters)
+        . (_) @_start (_) @_end .)
+      )
+  ] @block.outer
+   (#make-range! "block.inner" @_start @_end))
+
+[
+  (call
+    block: (_
+      !parameters
+      . (_) @block.inner .))
+
+  (call
+    block: (_
+      . parameters: (block_parameters)
+      . (_) @block.inner .))
+] @block.outer
+
+((lambda
+  body: (_
+    . (_) @_start (_) @_end .)
+  ) @block.outer
+ (#make-range! "block.inner" @_start @_end))
+
+(lambda
+  body: (_
+    . (_) @block.inner .) @block.outer)
 
 ;; calls
 (call
   method: (_) @call.inner ) @call.outer
 
 ;; classes
+(
+  [
+    (class
+      . name: (_) 
+      . superclass: (_)
+      . (_) @_start (_) @_end .)
+
+    (class
+      . name: (_) 
+      !superclass 
+      . (_) @_start (_) @_end .)
+
+    (module
+      . name: (_) 
+      . (_) @_start (_) @_end .)
+
+    (singleton_class
+      . value: (_) 
+      . (_) @_start (_) @_end .)
+  ] @class.outer
+ (#make-range! "class.inner" @_start @_end))
+
 [
   ;; match against classes with and without parrents
   (class
-    name: (constant)
-    superclass: (_)
-    (_) @class.inner)
+    . name: (_)
+    . superclass: (_)
+    . (_) @class.inner .)
 
   (class
-    name: (constant)
+    . name: (_)
     !superclass
-    (_) @class.inner)
+    . (_) @class.inner .)
 
   (module
-    name: (constant)
-    (_) @class.inner)
+    . name: (_)
+    . (_) @class.inner .)
+
+  (singleton_class
+    . value: (_)
+    . (_) @class.inner .)
 ] @class.outer
 
 ;; comments
@@ -48,17 +160,6 @@
     (_) @conditional.inner)
 ]  @conditional.outer
 
-;; functions
-[
-  (method
-    (identifier)
-    (_) @function.inner)
-
-  (singleton_method
-    (identifier)
-    (_) @function.inner)
-] @function.outer
-
 ;; loops
 [
   (while
@@ -78,9 +179,10 @@
 ] @loop.outer
 
 ;; parameters
-
 [
  (block_parameters (_) @parameter.inner)
 
- (method_parameters (_) @parameters.inner )
-] @parameters.outer
+ (method_parameters (_) @parameter.inner)
+
+ (lambda_parameters (_) @parameter.inner)
+] @parameter.outer


### PR DESCRIPTION
I saw this [PR](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/107) added some text objects for Ruby, but it has some bugs and unhandled cases.
So I created this PR to fix it. Hope you can take a look.
I'm Ruby dev, so I'm very glad if you can mention to me if have any changes in the Ruby text object, I can check it to be sure it's correct.

## Commit
Fix class, function and block text objects, tested with many cases from:
https://github.com/tree-sitter/tree-sitter-ruby

Add some cases for parameter text object.