### PR TITLE
Add elixir queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ EOF
 <tr>
 <td>dockerfile</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 <tr>
-<td>elixir</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
+<td>elixir</td><td> </td> <td> </td> <td> </td> <td> </td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td>👍</td> <td> </td> <td> </td> <td>👍</td> <td>👍</td> <td> </td> <td> </td> <td>👍</td> <td>👍</td> <td> </td> <td> </td> </tr>
 <tr>
 <td>elm</td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 <tr>

--- a/queries/elixir/textobjects.scm
+++ b/queries/elixir/textobjects.scm
@@ -7,10 +7,28 @@
   @function.inner))
   (anonymous_function (_) @function.inner)
 ] @function.outer
-[
-  (call function: (function_identifier) (module) (do_block (_) @class.inner))
-] @class.outer
+
+(call function: (function_identifier) (module) (do_block (_) @class.inner)) @class.outer
+
 ((unary_op (call function: (function_identifier) @_annotator (heredoc (heredoc_start)
  (heredoc_content) @comment.inner (heredoc_end)))) @comment.outer
  (#match? @_annotator "doc$"))
-(call (do_block (_) @block.inner)) @block.outer
+
+(comment) @comment.outer
+
+(call 
+  function: (function_identifier) @_call 
+  (do_block) @conditional.inner
+  (#any-of? @_call "if" "case" "cond")
+) @conditional.outer
+
+(arguments
+  "," @_start .
+  (_) @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+(arguments
+  . (_) @parameter.inner
+  . ","? @_end
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
+


### PR DESCRIPTION
Adding Elixir text objects.

Unfortunately, pretty much everything in the elixir grammar is a function or a call, so it's pretty hard to match some of the requested captures, as a lot of them would just be redundant. I followed the javascript queries to get as close as I can to matching what that matches and it's pretty spot on.

Adding:
- `@comment.outer` to match any `#comment`, though there was already a query to get module docs
- `@conditional.outer/inner` for all `if/cond/case`
- `@parameter.inner/outer` which matches arguments and parameters.

Altered:
- `@class.inner/outer` to remove the unneeded brackets.

Updating readme to match what was already there and what's new, as well.