### PR TITLE
fix: change example mappings for peek_definition_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ require'nvim-treesitter.configs'.setup {
       enable = true,
       border = 'none',
       peek_definition_code = {
-        ["df"] = "@function.outer",
-        ["dF"] = "@class.outer",
+        ["<leader>df"] = "@function.outer",
+        ["<leader>dF"] = "@class.outer",
       },
     },
   },

--- a/doc/nvim-treesitter-textobjects.txt
+++ b/doc/nvim-treesitter-textobjects.txt
@@ -142,8 +142,8 @@ Supported options:
         enable = true,
         border = "none",
         peek_definition_code = {
-          ["df"] = "@function.outer",
-          ["dF"] = "@class.outer",
+          ["<leader>df"] = "@function.outer",
+          ["<leader>dF"] = "@class.outer",
         },
       },
     },


### PR DESCRIPTION
If a user copies them,  find themselves with a very common operation in vim delete up to a word or backwards. I would think is better to recommend something that doesn't overwrite such a basic editor operation.

Speaking from experience 😄 