### PR TITLE
Added lookbehind functionality

### DIFF
--- a/.github/workflows/check_query_files.yml
+++ b/.github/workflows/check_query_files.yml
@@ -18,10 +18,12 @@ jobs:
         run: npm i -g tree-sitter
 
       - name: Prepare
+        env:
+          NVIM_TAG: v0.5.1
         run: |
           sudo apt-get update
           sudo add-apt-repository universe
-          wget https://github.com/neovim/neovim/releases/download/nightly/nvim.appimage
+          wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim.appimage
           chmod u+x nvim.appimage
           mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter-textobject/start
           ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter-textobject/start

--- a/lua/nvim-treesitter-textobjects.lua
+++ b/lua/nvim-treesitter-textobjects.lua
@@ -30,6 +30,7 @@ function M.init()
           return M.has_textobjects(lang) or has_some_textobject_mapping(lang)
         end,
         lookahead = false,
+        lookbehind = false,
         keymaps = {},
       },
       move = {

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -10,7 +10,13 @@ local M = {}
 
 function M.select_textobject(query_string, keymap_mode)
   local lookahead = configs.get_module("textobjects.select").lookahead
-  local bufnr, textobject = shared.textobject_at_point(query_string, nil, nil, { lookahead = lookahead })
+  local lookbehind = configs.get_module("textobjects.select").lookbehind
+  local bufnr, textobject = shared.textobject_at_point(
+    query_string,
+    nil,
+    nil,
+    { lookahead = lookahead, lookbehind = lookbehind }
+  )
   if textobject then
     ts_utils.update_selection(bufnr, textobject, M.detect_selection_mode(keymap_mode))
   end


### PR DESCRIPTION
Lookbehind is like lookahead but in the other direction. This can be useful if you want to select the function name from the function body with a custom query. If lookahead and lookbehind are configured as true, lookahead is dominant. As a further improvement i suggest that lookahead and lookbehind should be assigned to each keymap individually, because this will allow bindings like vim's integrated f for search forward and F for search backward.