### PR TITLE
Adds relevant text objects for Elm

### DIFF
--- a/queries/elm/textobjects.scm
+++ b/queries/elm/textobjects.scm
@@ -1,0 +1,58 @@
+;; Functions
+; top level function with type annotation and doc comment
+(
+  (module_declaration)
+  (block_comment) @function.outer.start
+  .
+  (type_annotation)
+  .
+  (value_declaration
+    body: (_)? @function.inner) @function.outer
+)
+
+; top level function with type annotation
+(
+  (module_declaration)
+  (type_annotation) @function.outer.start
+  .
+  (value_declaration
+    body: (_)? @function.inner) @function.outer
+)
+
+; top level function without type annotation
+(
+  (module_declaration)
+  (value_declaration
+    body: (_)? @function.inner) @function.outer
+)
+
+; Comments
+[
+  (block_comment)
+  (line_comment)
+] @comment.outer
+
+; Conditionals
+(if_else_expr
+    exprList: (_)
+    exprList: (_) @conditional.inner) @conditional.outer
+
+(case_of_expr
+    branch: (case_of_branch) @conditional.inner) @conditional.outer
+
+; Parameters
+((type_expression
+    (arrow) @_start .
+    [
+      (type_ref)
+    ] @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((type_expression
+    . [
+      (type_ref)
+    ] @parameter.inner
+    . (arrow)? @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end))

--- a/queries/elm/textobjects.scm
+++ b/queries/elm/textobjects.scm
@@ -26,7 +26,7 @@
     body: (_)? @function.inner) @function.outer
 )
 
-; Comments
+;; Comments
 [
   (block_comment)
   (line_comment)
@@ -40,19 +40,45 @@
 (case_of_expr
     branch: (case_of_branch) @conditional.inner) @conditional.outer
 
-; Parameters
+;; Parameters
+; type annotations
 ((type_expression
     (arrow) @_start .
-    [
-      (type_ref)
-    ] @parameter.inner
+    (type_ref) @parameter.inner
   )
   (#make-range! "parameter.outer" @_start @parameter.inner))
 
 ((type_expression
-    . [
-      (type_ref)
-    ] @parameter.inner
+    .
+    (type_ref) @parameter.inner
     . (arrow)? @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+; list items
+((list_expr
+    "," @_start .
+    exprList: (_) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((list_expr
+    .
+    exprList: (_) @parameter.inner
+    . ","? @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+; tuple items
+((tuple_expr
+    "," @_start .
+    expr: (_) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((tuple_expr
+    .
+    expr: (_) @parameter.inner
+    . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end))


### PR DESCRIPTION
Adds
  * comment.outer
  * conditional.inner
  * conditional.outer
  * function.inner
  * function.outer
  * parameter.inner
  * parameter.outer

I tried to add @block.inner and @block.outer for let/in expressions, but as of yet the query necessary given the available AST structure is beyond me. 

The behavior of @function.outer in particular is to my tastes, but may run counter to behavior in other languages. 

The full module level function block in Elm is composed of up to three parts, the function itself and one or both of a type annotation and doc comment above the function. The current implementation will grab these for @function.outer as greedily as possible. 

I feel selecting the type annotation is certainly correct and matches the existing behavior of python including decorators in @function.outer. I feel the doc comment should also be includes as its seems uncommon I would want to select an entire function and type annotation to move or delete without also wanting the doc comment, but it's obviously not strictly the function itself. I'd be very open to a mapping that allows combining @comment.outer + @function.outer, but I'm unaware of how to increase the selection in visual mode with further text objects. 