### PR TITLE
ci: open a PR to update README

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -9,10 +9,8 @@ jobs:
   update-readme:
     name: Update README.md
     runs-on: ubuntu-latest
-    if: github.ref != 'master'
     steps:
-      - uses: actions/checkout@v1
-
+      - uses: actions/checkout@v2
       - name: Prepare
         run: |
           sudo apt-get update
@@ -30,15 +28,18 @@ jobs:
 
       # inspired by nvim-lspconfigs
       - name: Check README
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMIT_MSG: |
-            [docgen] Update README.md
-            skip-checks: true
         run: |
           git config user.email "actions@github"
           git config user.name "Github Actions"
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          ./nvim.appimage --headless -c "luafile ./scripts/update-readme.lua" -c "q" || git add README.md
-          # Only commit and push if we have changes
-          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push origin HEAD:${GITHUB_REF})
+          ./nvim.appimage --headless -c "luafile ./scripts/update-readme.lua" -c "q"
+          git add README.md
+          git commit -m "Update README" || echo 'No commit necessary!'
+          git clean -xf
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Update README
+          title: Update README
+          branch: update-readme
+          base: ${{ github.head_ref }}


### PR DESCRIPTION
Fixes #138

Right now, due to branch protection rules (to enable auto-merge) prevent the bot from pushing to master