### PR TITLE
README: improve table of supported textobjs

### DIFF
--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -39,8 +39,8 @@ for _, v in ipairs(sorted_parsers) do
 
   for _, o in ipairs(textobjects) do
     local found = vim.tbl_contains(found_textobjects, o:sub(2))
-    local status =  found and "✅" or "⬜"
-    generated_text = generated_text .. "<td>" .. "<span title=\"" .. o .. "\">" .. status .. "</td> "
+    local status = found and "✅" or "⬜"
+    generated_text = generated_text .. "<td>" .. '<span title="' .. o .. '">' .. status .. "</td> "
   end
   generated_text = generated_text .. "</tr>\n"
 end

--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -39,8 +39,8 @@ for _, v in ipairs(sorted_parsers) do
 
   for _, o in ipairs(textobjects) do
     local found = vim.tbl_contains(found_textobjects, o:sub(2))
-    local status = found and "✅" or "⬜"
-    generated_text = generated_text .. "<td>" .. '<span title="' .. o .. '">' .. status .. "</td> "
+    local status = found and "🟩" or "⬜"
+    generated_text = generated_text .. "<td>" .. '<span title="' .. o .. '">' .. status .. "</span>" .. "</td> "
   end
   generated_text = generated_text .. "</tr>\n"
 end

--- a/scripts/update-readme.lua
+++ b/scripts/update-readme.lua
@@ -39,7 +39,8 @@ for _, v in ipairs(sorted_parsers) do
 
   for _, o in ipairs(textobjects) do
     local found = vim.tbl_contains(found_textobjects, o:sub(2))
-    generated_text = generated_text .. "<td>" .. (found and "👍" or " ") .. "</td> "
+    local status =  found and "✅" or "⬜"
+    generated_text = generated_text .. "<td>" .. "<span title=\"" .. o .. "\">" .. status .. "</td> "
   end
   generated_text = generated_text .. "</tr>\n"
 end


### PR DESCRIPTION
More easy to check what textobject the emoji is referring to. Tried using a check mark instead of the green square, but github colors those as gray

![Screenshot 2021-12-12 at 03-48-27 nvim-treesitter-textobjects README md at 577a9cd75a92f5a35e2d906ab5280f2a1b7f9fc1 · stsew](https://user-images.githubusercontent.com/4975310/145706129-06cb22ad-d31d-4615-8f28-8285c97e0913.png)

This is how it looks like with squares

![Screenshot 2021-12-12 at 03-47-28 nvim-treesitter-textobjects README md at preview · stsewd nvim-treesitter-textobjects](https://user-images.githubusercontent.com/4975310/145706145-68fc0191-9dd8-4606-b8ad-a45e76d98d64.png)

