### PR TITLE
Fix Go @parameter.outer not including trailing commas

### DIFF
--- a/queries/go/textobjects.scm
+++ b/queries/go/textobjects.scm
@@ -57,7 +57,7 @@
 (parameter_list
   . (parameter_declaration) @parameter.inner
   . ","? @_end
- (#make-range! "parameter.outer" @_start @parameter.inner))
+ (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (parameter_declaration
   (identifier)
@@ -80,4 +80,4 @@
 (argument_list
   . (_) @parameter.inner
   . ","? @_end
- (#make-range! "parameter.outer" @_start @parameter.inner))
+ (#make-range! "parameter.outer" @parameter.inner @_end))


### PR DESCRIPTION
This PR fixes the `@parameter.outer` queries for Go for the case where the comma optionally trails the parameter. They were previously making ranges using the same range as for the case where the comma precedes the parameter. This meant that if you had a config like
```
require('nvim-treesitter.configs').setup {
  textobjects = {
    select = {
      enable = true,
      keymaps = {
        ['aa'] = '@parameter.outer'
      }
    },
  }
}
```

and did a `daa` with your cursor in this position

```
func Add(x| int, y int) int {
    return x + y
}
```

then you would end up with 
```
func Add(|, y int) int {
    return x + y
}
```

rather than 

```
func Add(| y int) int {
	return x + y
}
```