### PR TITLE
Update per-language textobjects instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,6 @@ require'nvim-treesitter.configs'.setup {
         ["if"] = "@function.inner",
         ["ac"] = "@class.outer",
         ["ic"] = "@class.inner",
-
-        -- Or you can define your own textobjects like this
-        ["iF"] = {
-          python = "(function_definition) @function",
-          cpp = "(function_definition) @function",
-          c = "(function_definition) @function",
-          java = "(method_declaration) @function",
-        },
       },
     },
   },
@@ -136,6 +128,41 @@ require'nvim-treesitter.configs'.setup {
 }
 EOF
 ```
+
+# Overriding or extending textobjects
+
+Textobjects are defined in the `textobjects.scm` files.
+You can extend or override those files by following the instructions at
+<https://github.com/nvim-treesitter/nvim-treesitter#adding-queries>.
+You can also use a custom capture for your own textobjects,
+and use it in any of the textobject modules, for example:
+
+```scm
+-- after/queries/python/textobjects.scm
+
+(function_definition) @custom-capture
+```
+
+```
+lua <<EOF
+require'nvim-treesitter.configs'.setup {
+  textobjects = {
+    select = {
+      enable = true,
+      keymaps = {
+        -- Your custom capture.
+        ["aF"] = "@custom-capture",
+
+        -- Built-in captures.
+        ["af"] = "@function.outer",
+        ["if"] = "@function.inner",
+      },
+    },
+  },
+}
+EOF
+```
+
 ## Built-in Textobjects
 
 <!--textobjectinfo-->

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -7,13 +7,11 @@ local M = {}
 function M.make_attach(normal_mode_functions, submodule)
   return function(bufnr, lang)
     local config = configs.get_module("textobjects." .. submodule)
-    local lang = lang or parsers.get_buf_lang(bufnr)
+    lang = lang or parsers.get_buf_lang(bufnr)
 
     for _, function_call in pairs(normal_mode_functions) do
       for mapping, query in pairs(config[function_call] or {}) do
-        if type(query) == "table" then
-          query = query[lang]
-        elseif not queries.get_query(lang, "textobjects") then
+        if not queries.get_query(lang, "textobjects") then
           query = nil
         end
         if query then
@@ -37,9 +35,7 @@ function M.make_detach(normal_mode_functions, submodule)
     local lang = parsers.get_buf_lang(bufnr)
 
     for mapping, query in pairs(config.keymaps or {}) do
-      if type(query) == "table" then
-        query = query[lang]
-      elseif not queries.get_query(lang, "textobjects") then
+      if not queries.get_query(lang, "textobjects") then
         query = nil
       end
       if query then

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -49,12 +49,10 @@ end
 function M.attach(bufnr, lang)
   local buf = bufnr or api.nvim_get_current_buf()
   local config = configs.get_module "textobjects.select"
-  local lang = lang or parsers.get_buf_lang(buf)
+  lang = lang or parsers.get_buf_lang(buf)
 
   for mapping, query in pairs(config.keymaps) do
-    if type(query) == "table" then
-      query = query[lang]
-    elseif not queries.get_query(lang, "textobjects") then
+    if not queries.get_query(lang, "textobjects") then
       query = nil
     end
     if query then
@@ -72,9 +70,7 @@ function M.detach(bufnr)
   local lang = parsers.get_buf_lang(bufnr)
 
   for mapping, query in pairs(config.keymaps) do
-    if type(query) == "table" then
-      query = query[lang]
-    elseif not queries.get_query(lang, "textobjects") then
+    if not queries.get_query(lang, "textobjects") then
       query = nil
     end
     if query then

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -24,26 +24,10 @@ function M.textobject_at_point(query_string, pos, bufnr, opts)
   local row, col = unpack(pos or vim.api.nvim_win_get_cursor(0))
   row = row - 1
 
-  local matches = {}
-
-  if string.match(query_string, "^@.*") then
-    matches = queries.get_capture_matches_recursively(bufnr, query_string, "textobjects")
-  else
-    local parser = parsers.get_parser(bufnr, lang)
-
-    parser:for_each_tree(function(tree, lang_tree)
-      local lang = lang_tree:lang()
-      local start_row, _, end_row, _ = tree:root():range()
-      local query = queries.get_query(lang, "textobjects")
-      for m in queries.iter_prepared_matches(query, tree:root(), bufnr, start_row, end_row) do
-        for _, n in pairs(m) do
-          if n.node then
-            table.insert(matches, n)
-          end
-        end
-      end
-    end)
+  if not string.match(query_string, "^@.*") then
+    error 'Captures must start with "@"'
   end
+  local matches = queries.get_capture_matches_recursively(bufnr, query_string, "textobjects")
 
   local match_length
   local smallest_range


### PR DESCRIPTION
This feature hasn't been working for a long time.
And users can already override or extend textobjects
using the query files instead.

Options like these were working

```
{
  ["aF"] = {
    ["python"] = "@foo"
  }
}
```

Should we keep compatibility for those?
But that form wasn't documented, so not sure if there are people using it.

Closes https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/65
Closes https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/66/