### PR TITLE
Add support for parameter.outer for PHP

### DIFF
--- a/queries/php/textobjects.scm
+++ b/queries/php/textobjects.scm
@@ -23,8 +23,20 @@
 (_ (switch_block) @block.inner) @block.outer
 
 ;; parameters
-(formal_parameters
-  (simple_parameter) @parameter.inner)
-
 (arguments
-  (argument) @parameter.inner)
+  "," @_start .
+  (_) @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+(arguments
+  . (_) @parameter.inner
+  . ","? @_end
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
+(formal_parameters
+  "," @_start .
+  (_) @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+(formal_parameters
+  . (_) @parameter.inner
+  . ","? @_end
+ (#make-range! "parameter.outer" @parameter.inner @_end))


### PR DESCRIPTION
This code was stolen from https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/6ee11ac62681eb2eb8104a4ce509a9a861672cb5/queries/lua/textobjects.scm#L16-L32

I don't understand what the following block is about:

https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/6ee11ac62681eb2eb8104a4ce509a9a861672cb5/queries/lua/textobjects.scm#L34-L45