### PR TITLE
fix(java): use line_comment/block_comment instead of comment

### DIFF
--- a/queries/java/textobjects.scm
+++ b/queries/java/textobjects.scm
@@ -45,6 +45,9 @@
 (formal_parameters
   . (formal_parameter) @parameter.inner
   . ","? @_end
- (#make-range! "parameter.outer" @_start @parameter.inner))
+ (#make-range! "parameter.outer" @_end @parameter.inner))
 
-(comment) @comment.outer
+[
+  (line_comment)
+  (block_comment)
+] @comment.outer


### PR DESCRIPTION
This fixes the nightly running CI that failed due to the update of the Java parser.