### PR TITLE
fix(lua): adapt queries to upstream switch

### DIFF
--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -1,67 +1,77 @@
-(function) @function.outer
-(local_function) @function.outer
-(function_definition) @function.outer
+; block
 
-(for_in_statement) @loop.outer
-(for_statement) @loop.outer
-(while_statement) @loop.outer
-(repeat_statement) @loop.outer
+(_ (block) @block.inner) @block.outer
 
-(if_statement) @conditional.outer
+; call
 
-(function_call
-  (arguments) @call.inner)
-(function_call) @call.outer
+(function_call) @call.outer (arguments) @call.inner
 
-(arguments
-  "," @_start .
-  (_) @parameter.inner
- (#make-range! "parameter.outer" @_start @parameter.inner))
-(arguments
-  . (_) @parameter.inner
-  . ","? @_end
- (#make-range! "parameter.outer" @parameter.inner @_end))
+; class
 
-(parameters
-  "," @_start .
-  (_) @parameter.inner
- (#make-range! "parameter.outer" @_start @parameter.inner))
-(parameters
-  . (_) @parameter.inner
-  . ","? @_end
- (#make-range! "parameter.outer" @parameter.inner @_end))
-
-(arguments 
-  . (table
-    "," @_start .
-    (_) @parameter.inner
-   (#make-range! "parameter.outer" @_start @parameter.inner))
-  . ) 
-(arguments 
-  . (table
-    . (_) @parameter.inner
-    . ","? @_end
-   (#make-range! "parameter.outer" @parameter.inner @_end))
-  . ) 
+; comment
 
 (comment) @comment.outer
 
-((function
-  . (function_name) . (parameters) . (_) @_start
-  (_) @_end .)
- (#make-range! "function.inner" @_start @_end))
-((local_function
-  . (identifier) . (parameters) . (_) @_start
-  (_) @_end .)
- (#make-range! "function.inner" @_start @_end))
-((function_definition
-  . (parameters) . (_) @_start
-  (_) @_end .)
- (#make-range! "function.inner" @_start @_end))
+; conditional
 
-((function
-  . (function_name) . (parameters) . (_) @function.inner .))
-((local_function
-  . (identifier) . (parameters) . (_) @function.inner .))
-((function_definition
-  . (parameters) . (_) @function.inner .))
+(if_statement
+  alternative: (_ (_) @conditional.inner)?) @conditional.outer
+
+(if_statement
+  consequence: (block)? @conditional.inner)
+
+(if_statement
+  condition: (_) @conditional.inner)
+
+; frame
+
+; function
+
+[
+  (function_declaration)
+  (function_definition)
+] @function.outer
+
+(function_declaration body: (_) @function.inner)
+
+(function_definition body: (_) @function.inner)
+
+; loop
+
+[
+  (while_statement)
+  (for_statement)
+  (repeat_statement)
+] @loop.outer
+
+(while_statement body: (_) @loop.inner)
+
+(for_statement body: (_) @loop.inner)
+
+(repeat_statement body: (_) @loop.inner)
+
+; parameter
+
+(arguments
+  . (_) @parameter.inner
+  . ","? @_end
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+(parameters
+  . (_) @parameter.inner
+  . ","? @_end
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
+(arguments
+  "," @_start
+  . (_) @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+
+(parameters
+  "," @_start
+  . (_) @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+
+; scopename
+
+; statement


### PR DESCRIPTION
nvim-treesitter switched to a different Lua parser in https://github.com/nvim-treesitter/nvim-treesitter/pull/2272, which requires adaptation of queries

@MunifTanjim