### PR TITLE
Change config for swap and move to take a table of capture groups to increase configurability

### DIFF
--- a/doc/nvim-treesitter-textobjects.txt
+++ b/doc/nvim-treesitter-textobjects.txt
@@ -52,8 +52,9 @@ Query files: `textobjects.scm`.
 Supported options:
 - enable: `true` or `false`.
 - disable: list of languages.
-- swap_next: map of keymaps to a tree-sitter capture group (`@parameter.inner`).
-- swap_previous: same as swap_next.
+- swap_next: map of keymaps to a list of tree-sitter capture groups (`{@parameter.inner}`). Capture groups that come earlier in the list are preferred.
+- swap_previous: same as swap_next, but it will swap with the previous text
+  object.
 
 >
   lua <<EOF
@@ -62,10 +63,10 @@ Supported options:
       swap = {
         enable = true,
         swap_next = {
-          ["<leader>a"] = "@parameter.inner",
+          ["<leader>a"] = {"@parameter.inner"},
         },
         swap_previous = {
-          ["<leader>A"] = "@parameter.inner",
+          ["<leader>A"] = {"@parameter.inner"},
         },
       },
     },
@@ -86,7 +87,7 @@ Supported options:
 - enable: `true` or `false`.
 - disable: list of languages.
 - set_jumps: whether to set jumps in the jumplist
-- goto_next_start: map of keymaps to a tree-sitter capture group (`@function.outer`).
+- goto_next_start: map of keymaps to a list of tree-sitter capture groups (`{@function.outer, @class.outer}`). The one that starts closest to the cursor will be chosen, preferring row-proximity to column-proximity.
 - goto_next_end: same as goto_next_start, but it jumps to the start of
   the text object.
 - goto_previous_start: same as goto_next_start, but it jumps to the previous
@@ -102,20 +103,16 @@ Supported options:
         enable = true,
         set_jumps = true, -- whether to set jumps in the jumplist
         goto_next_start = {
-          ["]m"] = "@function.outer",
-          ["]]"] = "@class.outer",
+          ["]m"] = {"@function.outer", "@class.outer"},
         },
         goto_next_end = {
-          ["]M"] = "@function.outer",
-          ["]["] = "@class.outer",
+          ["]M"] = {"@function.outer", "@class.outer"},
         },
         goto_previous_start = {
-          ["[m"] = "@function.outer",
-          ["[["] = "@class.outer",
+          ["[m"] = {"@function.outer", "@class.outer"},
         },
         goto_previous_end = {
-          ["[M"] = "@function.outer",
-          ["[]"] = "@class.outer",
+          ["[M"] = {"@function.outer", "@class.outer"},
         },
       },
     },

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -10,18 +10,18 @@ function M.make_attach(normal_mode_functions, submodule)
     lang = lang or parsers.get_buf_lang(bufnr)
 
     for _, function_call in pairs(normal_mode_functions) do
-      for mapping, query in pairs(config[function_call] or {}) do
+      for mapping, config_queries in pairs(config[function_call] or {}) do
         if not queries.get_query(lang, "textobjects") then
-          query = nil
+          config_queries = nil
         end
-        if query then
+        if config_queries then
           local cmd = ":lua require'nvim-treesitter.textobjects."
             .. submodule
             .. "'."
             .. function_call
-            .. "('"
-            .. query
-            .. "')<CR>"
+            .. "({'"
+            .. table.concat(config_queries, "','")
+            .. "'})<CR>"
           api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true })
         end
       end

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -15,13 +15,20 @@ function M.make_attach(normal_mode_functions, submodule)
           config_queries = nil
         end
         if config_queries then
+          local config_query_str
+          if type(config_queries) == "string" then
+            config_query_str = "'" .. config_queries .. "'"
+          else
+            config_query_str = "{'" .. table.concat(config_queries, "','") .. "'}"
+          end
+
           local cmd = ":lua require'nvim-treesitter.textobjects."
             .. submodule
             .. "'."
             .. function_call
-            .. "({'"
-            .. table.concat(config_queries, "','")
-            .. "'})<CR>"
+            .. "("
+            .. config_query_str
+            .. ")<CR>"
           api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true })
         end
       end

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -1,14 +1,13 @@
 local ts_utils = require "nvim-treesitter.ts_utils"
 local attach = require "nvim-treesitter.textobjects.attach"
+local shared = require "nvim-treesitter.textobjects.shared"
 local queries = require "nvim-treesitter.query"
 local configs = require "nvim-treesitter.configs"
 
 local M = {}
 
 local function move(query_strings, forward, start, bufnr)
-  -- Support single query string in query_strings,
-  --    for compatability with old configs and the Vim commands
-  query_strings = type(query_strings) == "string" and { query_strings } or query_strings
+  query_strings = shared.make_query_strings_table(query_strings)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   local row, col = unpack(vim.api.nvim_win_get_cursor(0))
   row = row - 1 -- nvim_win_get_cursor is (1,0)-indexed

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -6,6 +6,11 @@ local ts_utils = require "nvim-treesitter.ts_utils"
 
 local M = {}
 
+-- Convert single query string to list for backwards compatibility and the Vim commands
+function M.make_query_strings_table(query_strings)
+  return type(query_strings) == "string" and { query_strings } or query_strings
+end
+
 function M.available_textobjects(lang)
   lang = lang or parsers.get_buf_lang()
   local parsed_queries = queries.get_query(lang, "textobjects")

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -4,8 +4,15 @@ local attach = require "nvim-treesitter.textobjects.attach"
 
 local M = {}
 
-local function swap_textobject(query_string, direction)
-  local bufnr, textobject_range, node = shared.textobject_at_point(query_string)
+local function swap_textobject(query_strings, direction)
+  local bufnr, textobject_range, node, query_string
+  for _, query_string_iter in pairs(query_strings) do
+    bufnr, textobject_range, node = shared.textobject_at_point(query_string_iter)
+    if node then
+      query_string = query_string_iter
+      break
+    end
+  end
   if not node then
     return
   end

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -5,8 +5,11 @@ local attach = require "nvim-treesitter.textobjects.attach"
 local M = {}
 
 local function swap_textobject(query_strings, direction)
+  -- Support single query string in query_strings,
+  --    for compatability with old configs and the Vim commands
+  query_strings = type(query_strings) == "string" and { query_strings } or query_strings
   local bufnr, textobject_range, node, query_string
-  for _, query_string_iter in pairs(query_strings) do
+  for _, query_string_iter in ipairs(query_strings) do
     bufnr, textobject_range, node = shared.textobject_at_point(query_string_iter)
     if node then
       query_string = query_string_iter

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -5,9 +5,7 @@ local attach = require "nvim-treesitter.textobjects.attach"
 local M = {}
 
 local function swap_textobject(query_strings, direction)
-  -- Support single query string in query_strings,
-  --    for compatability with old configs and the Vim commands
-  query_strings = type(query_strings) == "string" and { query_strings } or query_strings
+  query_strings = shared.make_query_strings_table(query_strings)
   local bufnr, textobject_range, node, query_string
   for _, query_string_iter in ipairs(query_strings) do
     bufnr, textobject_range, node = shared.textobject_at_point(query_string_iter)
@@ -16,7 +14,7 @@ local function swap_textobject(query_strings, direction)
       break
     end
   end
-  if not node then
+  if not query_string then
     return
   end
 


### PR DESCRIPTION
While I like this plugin a lot, the biggest complaint that I have (and have read) about it is that it requires a lot of keybinds to use effectively since they must be one per-capture-group per-action. Furthermore, many people (myself included) don't really care about the specific capture group being acted upon; rather, they want to act upon the first or closest capture group that makes sense for the action they're trying.

To be more concrete: I work a lot in Python. What I really want from this plugin are two things: (1) to easily move between major, meaningful parts of a file, and (2) to easily swap elements of lists (of arguments, dictionary entries, etc.). The over-broadness of `@parameter`, as pointed out in PR #86, is evidence that I am not alone in this desire, at least for the `swap` action/submodule.

My proposed solution is to change the values in the keybind maps for `move` and `swap` from single capture groups to lists of them. For `move`, the capture group chosen will be the one that starts (or ends) nearest to the cursor; for `swap`, it will be the one under the cursor that comes first in the configured list.

I'm new to Lua, so please be kind about criticisms relating to the quality of the code.