### PR TITLE
fix(fennel): each_clause does no longer exist

### DIFF
--- a/queries/fennel/textobjects.scm
+++ b/queries/fennel/textobjects.scm
@@ -38,7 +38,7 @@
   (_)? @_end .)
  (#make-range! "loop.inner" @_start @_end)) @loop.outer
 
-((each . (each_clause) .
+((each . (_) .
   (_) @_start .
   (_)* .
   (_)? @_end .)


### PR DESCRIPTION
See https://github.com/TravonteD/tree-sitter-fennel/pull/34/files

 The query tries to select from `[` to everything until ")"`. This seems to be be the behavior before. Though I would either select the loop body or the bindings....