### PR TITLE
fix(latex): update queries

### DIFF
--- a/queries/latex/textobjects.scm
+++ b/queries/latex/textobjects.scm
@@ -15,7 +15,7 @@
  (#make-range! "frame.inner" @_start @_end)) 
 
 [
-  (command)
+  (generic_command)
 ] @statement.outer
 
 [


### PR DESCRIPTION
Seems that [nvim-treesitter/nvim-treesitter#2591](https://github.com/nvim-treesitter/nvim-treesitter/pull/2591) has changed the `command` query into `generic_command`. If we don't modify this query in textobject. An error will occur when opening a latex file.