### PR TITLE
fix(r): parameter and argument

### DIFF
--- a/queries/r/textobjects.scm
+++ b/queries/r/textobjects.scm
@@ -54,11 +54,22 @@
 ; parameter
 
 ((formal_parameters
+  "," @_start .
+  (_) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((formal_parameters
   . (_) @parameter.inner
   . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end))
 
+((arguments
+  "," @_start .
+  (_) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
 
 ((arguments
   . (_) @parameter.inner


### PR DESCRIPTION
This should fix #198 

I hadn't mapped the `@_start`, my mistake.