### PR TITLE
[Elixir] Adds support for anonymous functions

### DIFF
--- a/queries/elixir/textobjects.scm
+++ b/queries/elixir/textobjects.scm
@@ -20,6 +20,11 @@
 ) @class.outer
 
 ; Function, Parameter, and Call Objects
+(anonymous_function
+  (stab_clause 
+    right: (body) @function.inner)
+) @function.outer
+
 (call 
   target: ((identifier) @_identifier (#any-of? @_identifier 
     "def" 


### PR DESCRIPTION
This patch extends @function.inner and @function.outer to also support
anonymous functions of the style

```
fn(x) ->
  x * x
end
```