### PR TITLE
Exclude curly braces on @function.inner in JavaScript arrow functions

### DIFF
--- a/queries/javascript/textobjects.scm
+++ b/queries/javascript/textobjects.scm
@@ -17,7 +17,11 @@
   (function_declaration) @function.outer) @function.outer.start
 
 (arrow_function
-  body: (_) @function.inner) @function.outer
+  . body: (_) @function.inner) @function.outer
+
+(arrow_function
+  body: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"
+ (#make-range! "function.inner" @_start @_end)))
 
 (method_definition
   body: (statement_block)) @function.outer


### PR DESCRIPTION
#196 excludes curly braces for `@function.inner`, but not for arrow functions in JavaScript.

I'm completely new to treesitter queries and Scheme so feel free to critique my solution.