### PR TITLE
ci: update CI to use latest stable

### DIFF
--- a/.github/workflows/check_query_files.yml
+++ b/.github/workflows/check_query_files.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Prepare
         env:
-          NVIM_TAG: v0.5.1
+          NVIM_TAG: stable
         run: |
           sudo apt-get update
           sudo add-apt-repository universe


### PR DESCRIPTION
This causes https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/212 to fail