### PR TITLE
Improve @function.inner for scala

### DIFF
--- a/queries/scala/textobjects.scm
+++ b/queries/scala/textobjects.scm
@@ -5,7 +5,7 @@
   body: (template_body)? @class.inner) @class.outer
 
 (function_definition
-  body: (block) @function.inner) @function.outer
+  body: (expression) @function.inner) @function.outer
 
 (parameter
   name: (identifier) @parameter.inner) @parameter.outer


### PR DESCRIPTION
Previously `@function.inner` would only capture function bodies wrapped in braces:

```scala
// Would capture
def foo: Int = {
  ...
}

// Wouldn't capture
def foo: Int = 3 * 10
```