### PR TITLE
Register key mappings to which-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ require'nvim-treesitter.configs'.setup {
         ["af"] = "@function.outer",
         ["if"] = "@function.inner",
         ["ac"] = "@class.outer",
-        ["ic"] = "@class.inner",
+        -- you can optionally set descriptions to the mappings (used in the desc parameter of nvim_buf_set_keymap
+        ["ic"] = { query = "@class.inner", desc = "Select inner part of a class region" },
       },
       -- You can choose the select mode (default is charwise 'v')
       selection_modes = {

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -1,7 +1,6 @@
 local configs = require "nvim-treesitter.configs"
 local parsers = require "nvim-treesitter.parsers"
 local queries = require "nvim-treesitter.query"
-local api = vim.api
 local M = {}
 
 function M.make_attach(normal_mode_functions, submodule)
@@ -10,26 +9,23 @@ function M.make_attach(normal_mode_functions, submodule)
     lang = lang or parsers.get_buf_lang(bufnr)
 
     for _, function_call in pairs(normal_mode_functions) do
+      local description = function_call:gsub("_", " ")
       for mapping, config_queries in pairs(config[function_call] or {}) do
         if not queries.get_query(lang, "textobjects") then
           config_queries = nil
         end
+        local desc
+        if type(config_queries) == "table" then
+          desc = config_queries.desc
+          config_queries = config_queries.query
+        end
+        if not desc then
+          desc = description:gsub("^%l", string.upper) .. " " .. config_queries
+        end
         if config_queries then
-          local config_query_str
-          if type(config_queries) == "string" then
-            config_query_str = "'" .. config_queries .. "'"
-          else
-            config_query_str = "{'" .. table.concat(config_queries, "','") .. "'}"
-          end
-
-          local cmd = ":lua require'nvim-treesitter.textobjects."
-            .. submodule
-            .. "'."
-            .. function_call
-            .. "("
-            .. config_query_str
-            .. ")<CR>"
-          api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true })
+          vim.keymap.set("n", mapping, function()
+            require("nvim-treesitter.textobjects." .. submodule)[function_call](config_queries)
+          end, { buffer = bufnr, silent = true, remap = false, desc = desc })
         end
       end
     end
@@ -46,8 +42,7 @@ function M.make_detach(normal_mode_functions, submodule)
         query = nil
       end
       if query then
-        api.nvim_buf_del_keymap(bufnr, "o", mapping)
-        api.nvim_buf_del_keymap(bufnr, "v", mapping)
+        vim.keymap.del({ "o", "x" }, mapping, { buffer = bufnr })
       end
     end
     for _, function_call in pairs(normal_mode_functions) do
@@ -58,7 +53,7 @@ function M.make_detach(normal_mode_functions, submodule)
           query = nil
         end
         if query then
-          api.nvim_buf_del_keymap(bufnr, "n", mapping)
+          vim.keymap.del("n", mapping, { buffer = bufnr })
         end
       end
     end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -129,14 +129,21 @@ function M.attach(bufnr, lang)
   lang = lang or parsers.get_buf_lang(buf)
 
   for mapping, query in pairs(config.keymaps) do
+    local desc
+    if type(query) == "table" then
+      desc = query.desc
+      query = query.query
+    end
+    if not desc then
+      desc = "Select textobject " .. query
+    end
     if not queries.get_query(lang, "textobjects") then
       query = nil
     end
     if query then
-      local cmd_o = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
-      api.nvim_buf_set_keymap(buf, "o", mapping, cmd_o, { silent = true, noremap = true })
-      local cmd_x = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
-      api.nvim_buf_set_keymap(buf, "x", mapping, cmd_x, { silent = true, noremap = true })
+      vim.keymap.set({ "o", "x" }, mapping, function()
+        require("nvim-treesitter.textobjects.select").select_textobject(query)
+      end, { buffer = buf, silent = true, remap = false, desc = desc })
     end
   end
 end
@@ -150,9 +157,11 @@ function M.detach(bufnr)
     if not queries.get_query(lang, "textobjects") then
       query = nil
     end
+    if type(query) == "table" then
+      query = query.query
+    end
     if query then
-      api.nvim_buf_del_keymap(buf, "o", mapping)
-      api.nvim_buf_del_keymap(buf, "x", mapping)
+      vim.keymap.del({ "o", "x" }, mapping, { buffer = buf })
     end
   end
 end


### PR DESCRIPTION
Fixes #232

@danielo515 are you using https://github.com/folke/which-key.nvim ? This should set description for this plugin. How can I register for telescope's which_key? Do want to additionally want to overwrite the automatically generated descriptions?

I don't think there is a generic way to set a description for a key mapping. ~~@folke maybe it would be an idea to add a "description" key to `opts` of `nvim_buf_add_keymap` that can be retrieved by new API function? It is difficult for third party plugins to annotate their keybindings that is not taylored to one specific which-key plugin ~~ (`nvim_buf_add_keymap` already has `desc`)

![grafik](https://user-images.githubusercontent.com/7189118/181906275-6ee2b866-1c95-4ac8-88fc-c96d1fe7677b.png)
