### PR TITLE
include surrounding whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ require'nvim-treesitter.configs'.setup {
         ['@function.outer'] = 'V', -- linewise
         ['@class.outer'] = '<c-v>', -- blockwise
       },
+      -- If you set this to `true` (default is `false`) then any textobject is
+      -- extended to include preceding xor succeeding whitespace. Succeeding
+      -- whitespace has priority in order to act similarly to eg the built-in
+      -- `ap`.
+      include_surrounding_whitespace = true,
     },
     },
   },

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -8,49 +8,15 @@ local ts_utils = require "nvim-treesitter.ts_utils"
 
 local M = {}
 
-function M.select_textobject(query_string, keymap_mode)
-  local lookahead = configs.get_module("textobjects.select").lookahead
-  local lookbehind = configs.get_module("textobjects.select").lookbehind
-  local include_surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
-  local bufnr, textobject =
-    shared.textobject_at_point(query_string, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
-  if textobject then
-    if include_surrounding_whitespace then
-      textobject = M.include_surrounding_whitespace(bufnr, textobject)
-    end
-    ts_utils.update_selection(bufnr, textobject, M.detect_selection_mode(query_string, keymap_mode))
+local function get_char_after_position(bufnr, row, col)
+  if row == nil then
+    return nil
   end
+  return vim.api.nvim_buf_get_text(bufnr, row, col, row, col + 1, {})[1]
 end
 
-function M.include_surrounding_whitespace(bufnr, textobject)
-  local start_row, start_col, end_row, end_col = unpack(textobject)
-  local extended = false
-  while M.is_whitespace_after(bufnr, end_row, end_col) do
-    extended = true
-    end_row, end_col = M.next_position(bufnr, end_row, end_col, true)
-  end
-  if extended then
-    -- don't extend in both directions
-    return { start_row, start_col, end_row, end_col }
-  end
-  local next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
-  while M.is_whitespace_after(bufnr, next_row, next_col) do
-    start_row = next_row
-    start_col = next_col
-    next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
-  end
-  return { start_row, start_col, end_row, end_col }
-end
-
-function M.is_whitespace_after(bufnr, row, col)
-  if col == #M.get_line(bufnr, row) then
-    if row == vim.api.nvim_buf_line_count(bufnr) then
-      return false
-    end
-    row = row + 1
-    col = 0
-  end
-  local char = M.get_char_after_position(bufnr, row, col)
+local function is_whitespace_after(bufnr, row, col)
+  local char = get_char_after_position(bufnr, row, col)
   if char == nil then
     return false
   end
@@ -60,15 +26,12 @@ function M.is_whitespace_after(bufnr, row, col)
   return string.match(char, "%s")
 end
 
-function M.get_char_after_position(bufnr, row, col)
-  if row == nil then
-    return nil
-  end
-  return vim.api.nvim_buf_get_text(bufnr, row, col, row, col + 1, {})[1]
+local function get_line(bufnr, row)
+  return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
 end
 
-function M.next_position(bufnr, row, col, forward)
-  local max_col = #M.get_line(bufnr, row)
+local function next_position(bufnr, row, col, forward)
+  local max_col = #get_line(bufnr, row)
   local max_row = vim.api.nvim_buf_line_count(bufnr)
   if forward then
     if col == max_col then
@@ -86,7 +49,7 @@ function M.next_position(bufnr, row, col, forward)
         return nil
       end
       row = row - 1
-      col = #M.get_line(bufnr, row)
+      col = #get_line(bufnr, row)
     else
       col = col - 1
     end
@@ -94,8 +57,38 @@ function M.next_position(bufnr, row, col, forward)
   return row, col
 end
 
-function M.get_line(bufnr, row)
-  return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
+local function include_surrounding_whitespace(bufnr, textobject)
+  local start_row, start_col, end_row, end_col = unpack(textobject)
+  local extended = false
+  while is_whitespace_after(bufnr, end_row, end_col) do
+    extended = true
+    end_row, end_col = next_position(bufnr, end_row, end_col, true)
+  end
+  if extended then
+    -- don't extend in both directions
+    return { start_row, start_col, end_row, end_col }
+  end
+  local next_row, next_col = next_position(bufnr, start_row, start_col, false)
+  while is_whitespace_after(bufnr, next_row, next_col) do
+    start_row = next_row
+    start_col = next_col
+    next_row, next_col = next_position(bufnr, start_row, start_col, false)
+  end
+  return { start_row, start_col, end_row, end_col }
+end
+
+function M.select_textobject(query_string, keymap_mode)
+  local lookahead = configs.get_module("textobjects.select").lookahead
+  local lookbehind = configs.get_module("textobjects.select").lookbehind
+  local surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
+  local bufnr, textobject =
+    shared.textobject_at_point(query_string, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
+  if textobject then
+    if surrounding_whitespace then
+      textobject = include_surrounding_whitespace(bufnr, textobject)
+    end
+    ts_utils.update_selection(bufnr, textobject, M.detect_selection_mode(query_string, keymap_mode))
+  end
 end
 
 function M.detect_selection_mode(query_string, keymap_mode)

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -11,11 +11,84 @@ local M = {}
 function M.select_textobject(query_string, keymap_mode)
   local lookahead = configs.get_module("textobjects.select").lookahead
   local lookbehind = configs.get_module("textobjects.select").lookbehind
+  local include_surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
   local bufnr, textobject =
     shared.textobject_at_point(query_string, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
   if textobject then
+    if include_surrounding_whitespace then
+      textobject = M.include_surrounding_whitespace(bufnr, textobject)
+    end
     ts_utils.update_selection(bufnr, textobject, M.detect_selection_mode(query_string, keymap_mode))
   end
+end
+
+function M.include_surrounding_whitespace(bufnr, textobject)
+  local start_row, start_col, end_row, end_col = unpack(textobject)
+  local extended = false
+  local next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
+  while M.is_whitespace_after(bufnr, next_row, next_col) do
+    extended = true
+    start_row = next_row
+    start_col = next_col
+    next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
+  end
+  if extended then
+    -- don't extend in both directions
+    return { start_row, start_col, end_row, end_col }
+  end
+  while M.is_whitespace_after(bufnr, end_row, end_col) do
+    end_row, end_col = M.next_position(bufnr, end_row, end_col, true)
+  end
+  return { start_row, start_col, end_row, end_col }
+end
+
+function M.is_whitespace_after(bufnr, row, col)
+  local char = M.get_char_after_position(bufnr, row, col)
+  if char == nil then
+    return false
+  end
+  if char == "" then
+    return true
+  end
+  return string.match(char, "%s")
+end
+
+function M.get_char_after_position(bufnr, row, col)
+  if row == nil then
+    return nil
+  end
+  return vim.api.nvim_buf_get_text(bufnr, row, col, row, col + 1, {})[1]
+end
+
+function M.next_position(bufnr, row, col, forward)
+  local max_col = #M.get_line(bufnr, row)
+  local max_row = vim.api.nvim_buf_line_count(bufnr)
+  if forward then
+    if col == max_col then
+      if row == max_row then
+        return nil
+      end
+      row = row + 1
+      col = 0
+    else
+      col = col + 1
+    end
+  else
+    if col == 0 then
+      if row == 0 then
+        return nil
+      end
+      row = row - 1
+      col = #M.get_line(bufnr, row)
+    else
+      col = col - 1
+    end
+  end
+  return row, col
+end
+
+function M.get_line(bufnr, row)
+  return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
 end
 
 function M.detect_selection_mode(query_string, keymap_mode)

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -25,24 +25,31 @@ end
 function M.include_surrounding_whitespace(bufnr, textobject)
   local start_row, start_col, end_row, end_col = unpack(textobject)
   local extended = false
-  local next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
-  while M.is_whitespace_after(bufnr, next_row, next_col) do
+  while M.is_whitespace_after(bufnr, end_row, end_col) do
     extended = true
-    start_row = next_row
-    start_col = next_col
-    next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
+    end_row, end_col = M.next_position(bufnr, end_row, end_col, true)
   end
   if extended then
     -- don't extend in both directions
     return { start_row, start_col, end_row, end_col }
   end
-  while M.is_whitespace_after(bufnr, end_row, end_col) do
-    end_row, end_col = M.next_position(bufnr, end_row, end_col, true)
+  local next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
+  while M.is_whitespace_after(bufnr, next_row, next_col) do
+    start_row = next_row
+    start_col = next_col
+    next_row, next_col = M.next_position(bufnr, start_row, start_col, false)
   end
   return { start_row, start_col, end_row, end_col }
 end
 
 function M.is_whitespace_after(bufnr, row, col)
+  if col == #M.get_line(bufnr, row) then
+    if row == vim.api.nvim_buf_line_count(bufnr) then
+      return false
+    end
+    row = row + 1
+    col = 0
+  end
   local char = M.get_char_after_position(bufnr, row, col)
   if char == nil then
     return false


### PR DESCRIPTION
This is an initial attempt to handle preceding/succeeding whitespace of textobjects and I'm looking for feedback. Initially mainly about the behaviour, which is opt-in. I think the current implementation can be made much better but that's a second question and I would first like to know if this makes sense :)

What this change does is that if the user enables it, it expands any textobject to include preceding or succeeding whitespace. It always tries to include any preceeding whitespace and if there is none instead tries to include succeeding whitespace (but never both). The ides is that it would work much like eg the built-in `aw`, `ap` etc. See the following screencast for a more concrete view:

https://user-images.githubusercontent.com/23341710/181994568-52c018b8-861d-4ec9-a2e9-847e88100e88.mp4

The implementation is currently very simple and probably quite inefficient since it just tries to walk one character backward of forward and see if there is more whitespace to consume. Maybe one could use a regex or so instead. I also considered using `ts_utils.get_previous_node` and use the end of that for the start of the current node, but that doesn't work so well if you're for example selecting the first argument to a function.

Related #69 