### PR TITLE
Selection no longer allows ad-hoc charwise selection

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -35,6 +35,7 @@ function M.detect_selection_mode(query_string, keymap_mode)
   elseif method == "operator-pending" then
     local ctrl_v = vim.api.nvim_replace_termcodes("<c-v>", true, true, true)
     local t = {
+      nov = "v",
       noV = "V",
       ["no" .. ctrl_v] = "<c-v>",
     }


### PR DESCRIPTION
Recent changes to make the selection modes configurable broke specifying
a charwise selection mode as part of the operator (e.g. `dvif` where
`if` is mapped to `@function.inner`). I believe charwise selection only
worked previously because it was the default used by
`ts_utils.update_selection`. We don't specify charwise selection in the
table under `elseif method == "operator-pending" then` in `select.lua`,
meaning we can't manually specify charwise selection if
`config.selection_modes[query_string]` is mapped to `V` or `<c-v>`.

This change adds an entry for `nov` (Operator-pending (forced
charwise)).

Fixes #236