### PR TITLE
feat: add support for heex

### DIFF
--- a/queries/heex/textobjects.scm
+++ b/queries/heex/textobjects.scm
@@ -1,0 +1,9 @@
+(tag) @function.outer
+
+(tag (start_tag) . (_) @function.inner . (end_tag))
+
+(attribute_value) @attribute.inner
+(attribute) @attribute.outer
+
+((tag (start_tag) . (_) @_start (_) @_end . (end_tag))
+ (#make-range! "function.inner" @_start @_end))


### PR DESCRIPTION
It's a subset of the `html` queries; and the `element` node has been renamed to `tag`, because that's the name in the `heex` grammar