### PR TITLE
Unify `@call.inner` capture

### DIFF
--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -41,7 +41,9 @@
 (comment) @comment.outer
 
 (call_expression) @call.outer
-(call_expression (_) @call.inner)
+(call_expression
+  arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ; Statements
 

--- a/queries/c_sharp/textobjects.scm
+++ b/queries/c_sharp/textobjects.scm
@@ -32,8 +32,10 @@
   body: (switch_body) @conditional.inner) @conditional.outer
 
 ;; calls
-(invocation_expression 
-  (argument_list) @call.inner) @call.outer
+(invocation_expression) @call.outer
+(invocation_expression
+  arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ;; blocks
 (_ (block) @block.inner) @block.outer

--- a/queries/dart/textobjects.scm
+++ b/queries/dart/textobjects.scm
@@ -55,8 +55,18 @@
  (#make-range! "parameter.outer" @_start @parameter.inner))
 
 ; call
-(expression_statement
-  (selector) @call.inner) @call.outer
+(
+ (identifier) @_start . (selector (argument_part) @_end)
+ (#make-range! "call.outer" @_start @_end)
+)
+
+(
+ (identifier) .
+ (selector
+   (argument_part
+     (arguments . "(" . (_) @_start (_)? @_end . ")"
+     (#make-range! "call.inner" @_start @_end))))
+)
 
 ; block
 (block) @block.outer

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -52,7 +52,9 @@
   body: (_)? @conditional.inner) @conditional.outer
 
 (call_expression) @call.outer
-(call_expression (arguments) @call.inner)
+(call_expression
+  arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ;; blocks
 (_ (statement_block) @block.inner) @block.outer

--- a/queries/fennel/textobjects.scm
+++ b/queries/fennel/textobjects.scm
@@ -19,9 +19,9 @@
 (parameters (_) @parameter.outer)
 
 ; call
-((list . [(multi_symbol) (symbol)] @call.inner) @call.outer
- (#not-any-of? @call.inner "if" "do" "while" "for" "let" "when"))
-
+((list . [(multi_symbol) (symbol)] @_sym . (_) @_start . (_)* . (_)? @_end .)
+ (#make-range! "call.inner" @_start @_end)
+ (#not-any-of? @_sym "if" "do" "while" "for" "let" "when")) @call.outer
 
 ; conditionals
 ((list . ((symbol) @_if (#any-of? @_if "if" "when")) . (_) .

--- a/queries/go/textobjects.scm
+++ b/queries/go/textobjects.scm
@@ -60,7 +60,10 @@
 (comment) @comment.outer
 
 ;; calls
-(call_expression (_)? @call.inner) @call.outer
+(call_expression) @call.outer
+(call_expression
+  arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ;; parameters
 (parameter_list

--- a/queries/haskell/textobjects.scm
+++ b/queries/haskell/textobjects.scm
@@ -1,5 +1,7 @@
-(exp_apply) @call.outer
-(exp_apply (_) @call.inner)
+(
+ (exp_apply . (exp_name) . (_) @_start . (_)* . (_)? @_end .)
+ (#make-range! "call.inner" @_start @_end)
+) @call.outer
 
 (function rhs: (_) @function.inner) @function.outer
 ;; also treat function signature as @function.outer

--- a/queries/java/textobjects.scm
+++ b/queries/java/textobjects.scm
@@ -41,7 +41,9 @@
 
 
 (method_invocation) @call.outer
-(method_invocation (argument_list) @call.inner)
+(method_invocation
+  arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ;; parameters
 (formal_parameters

--- a/queries/julia/textobjects.scm
+++ b/queries/julia/textobjects.scm
@@ -9,8 +9,10 @@
 (#make-range! "block.inner" @_start @_end)) @block.outer
 
 ; Calls
+(call_expression) @call.outer
 (call_expression
-  (argument_list) @call.inner) @call.outer
+  (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ; Objects (class)
 ((struct_definition

--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -4,7 +4,11 @@
 
 ; call
 
-(function_call) @call.outer (arguments) @call.inner
+(function_call) @call.outer ((arguments) @call.inner (#match? @call.inner "^[^\\(]"))
+
+(function_call
+  arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end))) @call.outer
 
 ; class
 

--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -4,7 +4,9 @@
 
 ; call
 
-(function_call) @call.outer ((arguments) @call.inner (#match? @call.inner "^[^\\(]"))
+(function_call
+  (arguments) @call.inner
+  (#match? @call.inner "^[^\\(]")) @call.outer
 
 (function_call
   arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -31,7 +31,9 @@
 (block (_) @statement.outer)
 
 (call) @call.outer
-(call (_) @call.inner)
+(call
+  arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ;; Parameters
 

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -68,7 +68,10 @@
 (unsafe_block (_)? @block.inner) @block.outer
 
 ;; calls
-(call_expression (_)? @call.inner) @call.outer
+(call_expression) @call.outer
+(call_expression
+  arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 
 ;; statements
 (block (_) @statement.outer)

--- a/queries/zig/textobjects.scm
+++ b/queries/zig/textobjects.scm
@@ -52,4 +52,7 @@
   (#make-range! "conditional.inner" @_start @_end))  @conditional.outer
 
 ;; calls
-(_ (FnCallArguments) @call.inner) @call.outer
+(_ (FnCallArguments)) @call.outer
+(_
+  (FnCallArguments . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))


### PR DESCRIPTION
This PR unifies `@call.inner` captures across languages that currently support it. Resolves #195.

Most languages currently have `@call.inner` select arguments *with* parenthesis.
General rule for selecting inner function call is taken to be "all arguments, without parenthesis, of function call". As a reference, captures from [cmake](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/4234c446d14370b3cd7604bd8e2e51ae2680f5ee/queries/cmake/textobjects.scm#L26-L30) are used, which after language-specific tweaks seem to work for most of the cases.

Notes:

- Although Cmake is already fully implemented, it is not mentioned in README.md (missing support of `@call.inner`). Didn't do anything, as it is an issue of 'scripts/update-readme.lua'.
- Having separate queries for `@call.outer` and `@call.inner` is needed to account for empty arguments (like `print()`): it doesn't have `@call.inner` capture but has `@call.outer`.
- Having `(_)?` instead of `(_)` in `"(" . (_) @_start (_)? @_end . ")"` expression is needed to work on call with single argument.
- Every explicit change was manually tested in examples containing function call with 0, 1, and more arguments. All seem to pass.
- In languages where function call is a variation of `f a b` (Fennel, Haskell), `@call.outer` is whole expression while `@call.inner` is all arguments (everything except first term). General idea for `@call.inner` query is taken from Fennel's function definition (which seems to work on my tested examples, but I might miss something here).
- With some of the languages I interacted for the first time here, so can totally miss something.

Affected languages:

- C
- C#
- C++. Done by C inheritance.
- Cuda. Done by C++ inheritance.
- Dart. There seems to be no hierarchical way of querying function call. Best I can tell, function call is an `identifier` followed by `selector` with `argument_part`. Currently it selects whole `expression_statement` as `@call.outer` which is suboptimal (it is too general and includes final `;`).
- Fennel. The `@call.inner` currently selects function *name* instead of call *arguments*. Changed to use function arguments.
- Glsl. Done by C inheritance.
- Go
- Haskell
- Java
- Javascript. Done by Ecma inheritance.
- Julia
- Lua. There are two queries to account for all function call cases: `print('aaa')`, `print'aaa'`, and `print{1, 2, 3}`.
- Python
- ~~R. Already fully implemented~~.
- Rust
- Tsx. Done by Typescript inheritance.
- Typescript. Done by Ecma inheritance.
- Zig