### PR TITLE
Enable javascript textobjects

### DIFF
--- a/queries/javascript/textobjects.scm
+++ b/queries/javascript/textobjects.scm
@@ -1,1 +1,1 @@
-; inherits: (ecma, jsx)
+; inherits: ecma


### PR DESCRIPTION
Currently none of the builtin textobjects (1 - 21) work for javascript. 

By changing the inheritance from `(ecma, jsx)` to just `ecma` it seems that at least `@function.outer` and `@function.inner` work fine (at least for simple javascript files). 

If the maintainers are open to this change then I would edit also the README.md to mark all the textobject that are actually supported.