### PR TITLE
Fix `@call.outer` in Lua to allow call with no arguments

### DIFF
--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -4,13 +4,15 @@
 
 ; call
 
+(function_call) @call.outer
+
 (function_call
   (arguments) @call.inner
-  (#match? @call.inner "^[^\\(]")) @call.outer
+  (#match? @call.inner "^[^\\(]"))
 
 (function_call
   arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"
-  (#make-range! "call.inner" @_start @_end))) @call.outer
+  (#make-range! "call.inner" @_start @_end)))
 
 ; class
 


### PR DESCRIPTION
This is a follow up to #250. I made its second commit in an attempt to clean Lua queries a little bit. But without proper extensive testing it inadvertently started rejecting function calls without arguments. This seems to fix it.

Sorry for the inconvenience.