### PR TITLE
fix: arrow function outer not being captured

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -16,7 +16,7 @@
   (function_declaration) @function.outer) @function.outer.start
 
 (arrow_function
-  . body: (_) @function.inner) @function.outer
+  body: (_) @function.inner) @function.outer
 
 (arrow_function
   body: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"


### PR DESCRIPTION
Fixes #215

Let me know if this dot had any reason for being there, but removing it fixed @function.outer in JavaScript for me.