### PR TITLE
skip keymap for lang not enabled

### DIFF
--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -12,19 +12,21 @@ function M.make_attach(normal_mode_functions, submodule)
       local description = function_call:gsub("_", " ")
       for mapping, config_queries in pairs(config[function_call] or {}) do
         if not queries.get_query(lang, "textobjects") then
-          local desc
-          if type(config_queries) == "table" then
-            desc = config_queries.desc
-            config_queries = config_queries.query
-          end
-          if not desc then
-            desc = description:gsub("^%l", string.upper) .. " " .. config_queries
-          end
-          if config_queries then
-            vim.keymap.set("n", mapping, function()
-              require("nvim-treesitter.textobjects." .. submodule)[function_call](config_queries)
-            end, { buffer = bufnr, silent = true, remap = false, desc = desc })
-          end
+          -- not enabled
+          config_queries = nil
+        end
+        local desc
+        if type(config_queries) == "table" then
+          desc = config_queries.desc
+          config_queries = config_queries.query
+        end
+        if not desc then
+          desc = description:gsub("^%l", string.upper) .. " " .. config_queries
+        end
+        if config_queries then
+          vim.keymap.set("n", mapping, function()
+            require("nvim-treesitter.textobjects." .. submodule)[function_call](config_queries)
+          end, { buffer = bufnr, silent = true, remap = false, desc = desc })
         end
         config_queries = nil
       end


### PR DESCRIPTION
Bugfix for: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/273
and : https://github.com/ray-x/navigator.lua/issues/225
