### PR TITLE
feat: R @statement.outer support

### DIFF
--- a/queries/r/textobjects.scm
+++ b/queries/r/textobjects.scm
@@ -51,6 +51,11 @@
 
 (for body: (_) @loop.inner)
 
+; statement
+(brace_list (_) @statement.outer)
+(program (_) @statement.outer)
+
+
 ; parameter
 
 ((formal_parameters


### PR DESCRIPTION
This pull request adds queries for @statement.outer in R. The design will properly detect top-level statements and statements within a function, loop, or conditional block

One slight weirdness of this design is that selecting the current statement from an empty line in a  brace_list selects the enclosing top-level statement, e.g. if the cursor is at the `|` character in the following example, a `@statement.outer` query will select the whole if statement.
```R
if (TRUE) {
   1+1
|
   2+2
}
```
I think this is acceptable behavior, and it would be challenging to change without causing other breakages. Just wanted to surface this in case there are concerns