### PR TITLE
feat: python support for top-level @statement.outer

### DIFF
--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -29,6 +29,7 @@
 (comment) @comment.outer
 
 (block (_) @statement.outer)
+(module (_) @statement.outer)
 
 (call) @call.outer
 (call


### PR DESCRIPTION
This adds support for top-level statements in Python `@statement.outer`, which enables statement selection in a scripting context where there is no enclosing block.