### PR TITLE
feat(select): allow settings for modes and whitespace to be callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ require'nvim-treesitter.configs'.setup {
         ["ic"] = { query = "@class.inner", desc = "Select inner part of a class region" },
       },
       -- You can choose the select mode (default is charwise 'v')
+      --
+      -- Can also be a function which gets passed a table with the keys
+      -- * query_string: eg '@function.inner'
+      -- * method: eg 'v' or 'o'
+      -- and should return the mode ('v', 'V', or '<c-v>') or a table
+      -- mapping query_strings to modes.
       selection_modes = {
         ['@parameter.outer'] = 'v', -- charwise
         ['@function.outer'] = 'V', -- linewise
@@ -52,6 +58,11 @@ require'nvim-treesitter.configs'.setup {
       -- extended to include preceding xor succeeding whitespace. Succeeding
       -- whitespace has priority in order to act similarly to eg the built-in
       -- `ap`.
+      --
+      -- Can also be a function which gets passed a table with the keys
+      -- * query_string: eg '@function.inner'
+      -- * selection_mode: eg 'v'
+      -- and should return true of false
       include_surrounding_whitespace = true,
     },
   },


### PR DESCRIPTION
This allows `selection_modes` and `include_surrounding_whitespace` to optionally be functions for dynamic settings.

For example I have now the following settings:
```lua
{
  ...
  -- for example only include whitespace for a<something> mappings and not i<something>
  include_surrounding_whitespace = function(opts)
    local obj, scope = unpack(vim.split(opts.query_string, '.', {plain = true}))
    return scope == 'outer'
  end,
  -- for example only use linewise for functions and classes in python
  selection_modes = function(opts)
    if vim.bo.filetype == 'python' then
      return {
        ["@class.outer"] = 'V',
        ["@class.inner"] = 'V',
        ["@function.outer"] = 'V',
        ["@function.inner"] = 'V',
      }
    end
  end,
  ...
}
```
