### PR TITLE
Clarify the need for extends modeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ and use it in any of the textobject modules, for example:
 
 ```scm
 -- after/queries/python/textobjects.scm
-
+; extends
 (function_definition) @custom-capture
 ```
 


### PR DESCRIPTION
...when overriding/extending textobjects.

I just found out that, in v0.8.0, you're supposed to start the file with `; extends`, otherwise the file will be ignored (only one query file will be considered).

See https://github.com/neovim/neovim/pull/20105/ and https://github.com/neovim/neovim/issues/20172