### PR TITLE
fix(rust): remove `if_let_expression` and `while_let_expression`

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -47,24 +47,11 @@
 
 (match_expression) @conditional.outer
 
-(if_let_expression
-  consequence: (block)?
-  @conditional.inner) @conditional.outer
-
-(if_let_expression
-  alternative: (else_clause (block) @conditional.inner))
-
-(if_let_expression
-  pattern: (_) @conditional.inner)
-
 ;; loops
 (loop_expression
   (_)? @loop.inner) @loop.outer
 
 (while_expression
-  (_)? @loop.inner) @loop.outer
-
-(while_let_expression
   (_)? @loop.inner) @loop.outer
 
 (for_expression
@@ -137,11 +124,3 @@
 ((type_arguments
   . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
-
-((meta_arguments
-  "," @_start . (_) @parameter.inner)
- (#make-range! "parameter.outer" @_start @parameter.inner))
-((meta_arguments
-  . (_) @parameter.inner . ","? @_end)
- (#make-range! "parameter.outer" @parameter.inner @_end))
-


### PR DESCRIPTION
I briefly checked and it seems `{if,while}_let_expression` can be replace 1:1 by existing `{if,while}_expression` queries.

This PR also removes `meta_arguments` related queries because it was giving the same error.

Fixes #316 