### PR TITLE
Move object supports visual and operator-pending modes

### DIFF
--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -3,7 +3,8 @@ local parsers = require "nvim-treesitter.parsers"
 local queries = require "nvim-treesitter.query"
 local M = {}
 
-function M.make_attach(normal_mode_functions, submodule)
+function M.make_attach(normal_mode_functions, submodule, keymap_modes)
+  keymap_modes = keymap_modes or "n"
   return function(bufnr, lang)
     lang = lang or parsers.get_buf_lang(bufnr)
     if not queries.get_query(lang, "textobjects") then
@@ -25,7 +26,7 @@ function M.make_attach(normal_mode_functions, submodule)
           mapping_description = function_description .. " " .. query_metadata
         end
 
-        vim.keymap.set({ "n", "o", "x" }, mapping, function()
+        vim.keymap.set(keymap_modes, mapping, function()
           require("nvim-treesitter.textobjects." .. submodule)[function_call](query)
         end, { buffer = bufnr, silent = true, remap = false, desc = mapping_description })
       end
@@ -33,7 +34,8 @@ function M.make_attach(normal_mode_functions, submodule)
   end
 end
 
-function M.make_detach(normal_mode_functions, submodule)
+function M.make_detach(normal_mode_functions, submodule, keymap_modes)
+  keymap_modes = keymap_modes or "n"
   return function(bufnr)
     local config = configs.get_module("textobjects." .. submodule)
     local lang = parsers.get_buf_lang(bufnr)
@@ -54,7 +56,7 @@ function M.make_detach(normal_mode_functions, submodule)
           query = nil
         end
         if query then
-          vim.keymap.del({ "n", "o", "x" }, mapping, { buffer = bufnr })
+          vim.keymap.del(keymap_modes, mapping, { buffer = bufnr })
         end
       end
     end

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -25,7 +25,7 @@ function M.make_attach(normal_mode_functions, submodule)
           mapping_description = function_description .. " " .. query_metadata
         end
 
-        vim.keymap.set("n", mapping, function()
+        vim.keymap.set({ "n", "o", "x" }, mapping, function()
           require("nvim-treesitter.textobjects." .. submodule)[function_call](query)
         end, { buffer = bufnr, silent = true, remap = false, desc = mapping_description })
       end
@@ -54,7 +54,7 @@ function M.make_detach(normal_mode_functions, submodule)
           query = nil
         end
         if query then
-          vim.keymap.del("n", mapping, { buffer = bufnr })
+          vim.keymap.del({ "n", "o", "x" }, mapping, { buffer = bufnr })
         end
       end
     end

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -6,7 +6,10 @@ local M = {}
 
 local floating_win
 
-local normal_mode_functions = {
+-- peeking is not interruptive so it is okay to use in visual mode.
+-- in fact, visual mode peeking is very helpful because you may not want
+-- to jump to the definition.
+local nx_mode_functions = {
   "peek_definition_code",
 }
 
@@ -107,8 +110,8 @@ function M.peek_definition_code(textobject, lsp_request, context)
   end
 end
 
-M.attach = attach.make_attach(normal_mode_functions, "lsp_interop")
-M.detach = attach.make_detach(normal_mode_functions, "lsp_interop")
+M.attach = attach.make_attach(nx_mode_functions, "lsp_interop", { "n", "x" })
+M.detach = attach.make_detach(nx_mode_functions, "lsp_interop", { "n", "x" })
 M.commands = {
   TSTextobjectPeekDefinitionCode = {
     run = M.peek_definition_code,

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -82,10 +82,10 @@ M.goto_previous_end = function(query_strings)
   move(query_strings, not "forward", not "start")
 end
 
-local normal_mode_functions = { "goto_next_start", "goto_next_end", "goto_previous_start", "goto_previous_end" }
+local nxo_mode_functions = { "goto_next_start", "goto_next_end", "goto_previous_start", "goto_previous_end" }
 
-M.attach = attach.make_attach(normal_mode_functions, "move")
-M.detach = attach.make_detach(normal_mode_functions, "move")
+M.attach = attach.make_attach(nxo_mode_functions, "move", { "n", "x", "o" })
+M.detach = attach.make_detach(nxo_mode_functions, "move", { "n", "x", "o" })
 
 M.commands = {
   TSTextobjectGotoNextStart = {

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -38,8 +38,8 @@ end
 
 local normal_mode_functions = { "swap_next", "swap_previous" }
 
-M.attach = attach.make_attach(normal_mode_functions, "swap")
-M.detach = attach.make_detach(normal_mode_functions, "swap")
+M.attach = attach.make_attach(normal_mode_functions, "swap", "n")
+M.detach = attach.make_detach(normal_mode_functions, "swap", "n")
 
 M.commands = {
   TSTextobjectSwapNext = {


### PR DESCRIPTION
This pull request resolves #6, to make the move operation consistent with vim's behaviour.
Now you can move in visual mode or operator-pending mode.
For example,

`v]M` will select until the end of the function, assuming the key binding following the README.  
`dv]M` will delete until the end of the function.