### PR TITLE
Fix GitHub Actions check query files

### DIFF
--- a/.github/workflows/check_query_files.yml
+++ b/.github/workflows/check_query_files.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           NVIM_TAG: stable
         run: |
-          sudo apt-get update
+          sudo apt-get update && sudo apt-get install libfuse2
           sudo add-apt-repository universe
           wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim.appimage
           chmod u+x nvim.appimage


### PR DESCRIPTION
The latest Ubuntu doesn't come with libfuse2, so the appimage wouldn't run without this dependency as shown below.  
This pull request fixes this issue and re-enables checking query files Action.

Problem:  
![image](https://user-images.githubusercontent.com/12980409/206570953-f449baa5-2288-425b-bec3-6f75b91306c4.png)

Fix:  
![image](https://user-images.githubusercontent.com/12980409/206571395-2bdf0b15-ca7d-4cb4-a532-fad55dafba5a.png)

