### PR TITLE
fix(julia): fix `index_expression`

### DIFF
--- a/queries/julia/textobjects.scm
+++ b/queries/julia/textobjects.scm
@@ -89,15 +89,10 @@
   (#make-range! "call.inner" @_start @_end)))
 
 ;; Parameters
-((index_expression
+((vector_expression
     "," @_start . 
     (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner)) 
-
-((index_expression
-    . (_) @parameter.inner 
-    . ","? @_end)
- (#make-range! "parameter.outer" @parameter.inner @_end)) 
 
 ((argument_list
     "," @_start .


### PR DESCRIPTION
index_expression has no longer `","` children. The children are now either `vector_expression`, `matrix_expression` or `comprehension_expression`.

@kiyoon feel free to merge. Each PR should have at least one review of one of the maintainers. `nvim-treesitter-textobjects` has a nightly CI that detects breakages like this one.

@clason had the idea to move textobject queries back to the upstream repo. We could also test nvim-treesitter-textobject in the main repo to be warned when a change would break one of the textobject queries. Since the revision of this plugin moves independently from nvim-treesitter. We can't guarantee that parser and queries match.