### PR TITLE
Use <cmd> in keymapping to prevent flicker on some UIs

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -176,9 +176,9 @@ function M.attach(bufnr, lang)
       --vim.keymap.set({ "o", "x" }, mapping, function()
       --require("nvim-treesitter.textobjects.select").select_textobject(query)
       --end, { buffer = buf, silent = true, remap = false, desc = desc })
-      local cmd_o = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
+      local cmd_o = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
       api.nvim_buf_set_keymap(buf, "o", mapping, cmd_o, { silent = true, noremap = true, desc = desc })
-      local cmd_x = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
+      local cmd_x = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
       api.nvim_buf_set_keymap(buf, "x", mapping, cmd_x, { silent = true, noremap = true, desc = desc })
     end
   end


### PR DESCRIPTION
Using `:` in the mapping causes some UIs to glitch when repeating a command (`.`) on a textobject. `<cmd>` prevents that.

![flicker](https://user-images.githubusercontent.com/22773951/209072032-299ed613-2726-4129-824d-1178c510a5da.gif)