### PR TITLE
Revert "Use <cmd> in keymapping to prevent flicker on some UIs"

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -176,9 +176,9 @@ function M.attach(bufnr, lang)
       --vim.keymap.set({ "o", "x" }, mapping, function()
       --require("nvim-treesitter.textobjects.select").select_textobject(query)
       --end, { buffer = buf, silent = true, remap = false, desc = desc })
-      local cmd_o = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
+      local cmd_o = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
       api.nvim_buf_set_keymap(buf, "o", mapping, cmd_o, { silent = true, noremap = true, desc = desc })
-      local cmd_x = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
+      local cmd_x = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
       api.nvim_buf_set_keymap(buf, "x", mapping, cmd_x, { silent = true, noremap = true, desc = desc })
     end
   end


### PR DESCRIPTION
This reverts commit 4c9bcaaabcc9b978871b97ee6142417f77aa0b53.

Fixes #344