### PR TITLE
fix(julia): Remove `type_parameters` field name

### DIFF
--- a/queries/julia/textobjects.scm
+++ b/queries/julia/textobjects.scm
@@ -51,7 +51,8 @@
 )(#make-range! "class.inner" @_start @_end)) @class.outer
 
 ((struct_definition
-  name: (_) type_parameters: (_)
+  name: (_)
+  (type_parameter_list)*
   . (_)? @_start
   (_) @_end .
   "end"


### PR DESCRIPTION
See https://github.com/tree-sitter/tree-sitter-julia/pull/85 and https://github.com/nvim-treesitter/nvim-treesitter/pull/4016