### PR TITLE
fix (select): Rewrite detect_selection_mode function

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -162,14 +162,9 @@ function M.attach(bufnr, lang)
       query = nil
     end
     if query then
-      --- Does not currently work in visual mode
-      --vim.keymap.set({ "o", "x" }, mapping, function()
-      --require("nvim-treesitter.textobjects.select").select_textobject(query)
-      --end, { buffer = buf, silent = true, remap = false, desc = desc })
-      local cmd_o = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
-      api.nvim_buf_set_keymap(buf, "o", mapping, cmd_o, { silent = true, noremap = true, desc = desc })
-      local cmd_x = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
-      api.nvim_buf_set_keymap(buf, "x", mapping, cmd_x, { silent = true, noremap = true, desc = desc })
+      vim.keymap.set({ "o", "x" }, mapping, function()
+        require("nvim-treesitter.textobjects.select").select_textobject(query)
+      end, { buffer = buf, silent = true, remap = false, desc = desc })
     end
   end
 end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -134,15 +134,12 @@ function M.detect_selection_mode(query_string, keymap_mode)
     selection_mode = selection_modes or "v"
   end
 
-  if method == "visual" or method == "operator-pending" then
-    -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
-    -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
-    -- last set `selection_mode`
-    local visual_mode = vim.fn.mode(1)
-    visual_mode = visual_mode:sub(#visual_mode)
-    selection_mode = visual_mode == "o" and selection_mode or visual_mode
-    print(selection_mode)
-  end
+  -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
+  -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
+  -- last set `selection_mode`
+  local visual_mode = vim.fn.mode(1)
+  visual_mode = visual_mode:sub(#visual_mode)
+  selection_mode = visual_mode == "o" and selection_mode or visual_mode
 
   return selection_mode
 end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -134,24 +134,17 @@ function M.detect_selection_mode(query_string, keymap_mode)
     selection_mode = selection_modes or "v"
   end
 
-  if method == "visual" then
-    selection_mode = vim.fn.visualmode()
-  elseif method == "operator-pending" then
-    local ctrl_v = vim.api.nvim_replace_termcodes("<c-v>", true, true, true)
-    local t = {
-      nov = "v",
-      noV = "V",
-      ["no" .. ctrl_v] = "<c-v>",
-    }
-    selection_mode = t[vim.fn.mode(1)] or selection_mode
+  if method == "visual" or method == "operator-pending" then
+    -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
+    -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
+    -- last set `selection_mode`
+    local visual_mode = vim.fn.mode(1)
+    visual_mode = visual_mode:sub(#visual_mode)
+    selection_mode = visual_mode == "o" and selection_mode or visual_mode
+    print(selection_mode)
   end
 
-  local t = {
-    v = "charwise",
-    V = "linewise",
-    ["<c-v>"] = "blockwise",
-  }
-  return t[selection_mode]
+  return selection_mode
 end
 
 function M.attach(bufnr, lang)
@@ -176,9 +169,9 @@ function M.attach(bufnr, lang)
       --vim.keymap.set({ "o", "x" }, mapping, function()
       --require("nvim-treesitter.textobjects.select").select_textobject(query)
       --end, { buffer = buf, silent = true, remap = false, desc = desc })
-      local cmd_o = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
+      local cmd_o = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
       api.nvim_buf_set_keymap(buf, "o", mapping, cmd_o, { silent = true, noremap = true, desc = desc })
-      local cmd_x = ":lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
+      local cmd_x = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
       api.nvim_buf_set_keymap(buf, "x", mapping, cmd_x, { silent = true, noremap = true, desc = desc })
     end
   end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -162,9 +162,10 @@ function M.attach(bufnr, lang)
       query = nil
     end
     if query then
-      vim.keymap.set({ "o", "x" }, mapping, function()
-        require("nvim-treesitter.textobjects.select").select_textobject(query)
-      end, { buffer = buf, silent = true, remap = false, desc = desc })
+      local cmd_o = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
+      local cmd_x = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
+      vim.keymap.set({ "o" }, mapping, cmd_o, { buffer = buf, silent = true, remap = false, desc = desc })
+      vim.keymap.set({ "x" }, mapping, cmd_x, { buffer = buf, silent = true, remap = false, desc = desc })
     end
   end
 end


### PR DESCRIPTION
@theHamsta Could you test that with the suggested changes made in nvim-treesitter (https://github.com/nvim-treesitter/nvim-treesitter/pull/4015)?

On my end, everything seems to be working well. In particular, I can do `Vaf` or `vaf` and it will respect the selection mode. If user has put a preference for selection mode in config, then config will take precedence.

*Edit*: ~I need to remove debug print statement.~

I also reintroduced the `<cmd>` instead of `:` in mapping. We could translate it directly to `vim.keymap.set` in this PR.