### PR TITLE
feat(lsp_interop): Add max win height option for floating window

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ require'nvim-treesitter.configs'.setup {
     lsp_interop = {
       enable = true,
       border = 'none',
-      max_height = 0,
+      floating_preview_opts = {},
       peek_definition_code = {
         ["<leader>df"] = "@function.outer",
         ["<leader>dF"] = "@class.outer",

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ require'nvim-treesitter.configs'.setup {
     lsp_interop = {
       enable = true,
       border = 'none',
+      max_height = 0,
       peek_definition_code = {
         ["<leader>df"] = "@function.outer",
         ["<leader>dF"] = "@class.outer",
@@ -189,6 +190,7 @@ EOF
 ## Built-in Textobjects
 
 <!--textobjectinfo-->
+
 1. @attribute.inner
 2. @attribute.outer
 3. @block.inner

--- a/doc/nvim-treesitter-textobjects.txt
+++ b/doc/nvim-treesitter-textobjects.txt
@@ -157,8 +157,8 @@ LSP interop~
 Supported options:
 - enable: `true` or `false`.
 - border: 'none' (default), 'single', 'double', 'rounded', 'solid', 'shadow'.
-- max_height: `0` (default). Set maximum height of floating window. 0 is no
-  max.
+  Deprecated. Should be placed in `floating_preview_opts` like so: `floating_preview_opts = {border = 'rounded'}`.
+- floating_preview_opts: {} (default). Options to pass to `vim.lsp.util.open_floating_preview`. For example, `maximum_height`.
 >
   lua <<EOF
   require'nvim-treesitter.configs'.setup {
@@ -166,7 +166,7 @@ Supported options:
       lsp_interop = {
         enable = true,
         border = "none",
-        max_height = 0,
+        floating_preview_opts = {},
         peek_definition_code = {
           ["<leader>df"] = "@function.outer",
           ["<leader>dF"] = "@class.outer",

--- a/doc/nvim-treesitter-textobjects.txt
+++ b/doc/nvim-treesitter-textobjects.txt
@@ -157,6 +157,8 @@ LSP interop~
 Supported options:
 - enable: `true` or `false`.
 - border: 'none' (default), 'single', 'double', 'rounded', 'solid', 'shadow'.
+- max_height: `0` (default). Set maximum height of floating window. 0 is no
+  max.
 >
   lua <<EOF
   require'nvim-treesitter.configs'.setup {
@@ -164,6 +166,7 @@ Supported options:
       lsp_interop = {
         enable = true,
         border = "none",
+        max_height = 0,
         peek_definition_code = {
           ["<leader>df"] = "@function.outer",
           ["<leader>dF"] = "@class.outer",

--- a/lua/nvim-treesitter-textobjects.lua
+++ b/lua/nvim-treesitter-textobjects.lua
@@ -57,7 +57,7 @@ function M.init()
         module_path = "nvim-treesitter.textobjects.lsp_interop",
         enable = false,
         border = "none",
-        max_height = 0,
+        floating_preview_opts = {},
         disable = {},
         is_supported = M.has_textobjects,
         peek_definition_code = {},

--- a/lua/nvim-treesitter-textobjects.lua
+++ b/lua/nvim-treesitter-textobjects.lua
@@ -57,6 +57,7 @@ function M.init()
         module_path = "nvim-treesitter.textobjects.lsp_interop",
         enable = false,
         border = "none",
+        max_height = 0,
         disable = {},
         is_supported = M.has_textobjects,
         peek_definition_code = {},

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -45,10 +45,8 @@ function M.preview_location(location, context)
   end
 
   local config = configs.get_module "textobjects.lsp_interop"
-  local opts = {}
-  if config.max_height > 0 then
-    opts.max_height = config.max_height
-  end
+  local opts = config.floating_preview_opts or {}
+
   if config.border ~= "none" then
     opts.border = config.border
   end

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -46,6 +46,9 @@ function M.preview_location(location, context)
 
   local config = configs.get_module "textobjects.lsp_interop"
   local opts = {}
+  if config.max_height > 0 then
+    opts.max_height = config.max_height
+  end
   if config.border ~= "none" then
     opts.border = config.border
   end


### PR DESCRIPTION
Add the possibility to specify a maximum height for floating window, so it does not fill all the screen.