### PR TITLE
Repeat movements like `;` and `,`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ vim.keymap.set({ "n", "x", "o" }, "t", ts_repeat_move.builtin_t)
 vim.keymap.set({ "n", "x", "o" }, "T", ts_repeat_move.builtin_T)
 ```
 
+You can even make a custom repeat behaviour.
+
+````lua
+local function repeat_last_move_next_end()
+  -- This repeats last query with always forward direction and end of the range.
+  return ts_repeat_move.repeat_last_move({forward = true, start = false})
+end
+vim.keymap.set({ "n", "x", "o" }, "<end>", repeat_last_move_next_end)
+```
+
 Furthermore, you can make any custom movements (e.g. from another plugin) repeatable with the same keys.
 This doesn't need to be treesitter-related.
 
@@ -187,7 +197,7 @@ local right2_repeat, left2_repeat = ts_repeat_move.make_repeatable_move_pair(rig
 
 vim.keymap.set({ "n", "x", "o" }, "l", right2_repeat)
 vim.keymap.set({ "n", "x", "o" }, "h", left2_repeat)
-```
+````
 
 Alternative way is to use a repeatable movement managing plugin such as [nvim-next](https://github.com/ghostbuster91/nvim-next).
 

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -6,6 +6,10 @@ local configs = require "nvim-treesitter.configs"
 
 local M = {}
 
+M.last_move = nil
+-- { func = move, args = { ... } }
+-- { func = builtin_find, args = { ... } }
+
 local function move(query_strings, forward, start, winid)
   query_strings = shared.make_query_strings_table(query_strings)
   winid = winid or vim.api.nvim_get_current_win()
@@ -70,16 +74,157 @@ local function move(query_strings, forward, start, winid)
 end
 
 M.goto_next_start = function(query_strings)
-  move(query_strings, "forward", "start")
+  local args = { query_strings, "forward", "start" }
+  move(unpack(args))
+  M.last_move = { func = move, args = args }
 end
 M.goto_next_end = function(query_strings)
-  move(query_strings, "forward", not "start")
+  local args = { query_strings, "forward", not "start" }
+  move(unpack(args))
+  M.last_move = { func = move, args = args }
 end
 M.goto_previous_start = function(query_strings)
-  move(query_strings, not "forward", "start")
+  local args = { query_strings, not "forward", "start" }
+  move(unpack(args))
+  M.last_move = { func = move, args = args }
 end
 M.goto_previous_end = function(query_strings)
-  move(query_strings, not "forward", not "start")
+  local args = { query_strings, not "forward", not "start" }
+  move(unpack(args))
+  M.last_move = { func = move, args = args }
+end
+
+-- implements naive f, F, t, T with repeat support
+local function builtin_find(forward, inclusive, char, repeating)
+  -- forward = true -> f, t
+  -- inclusive = false -> t, T
+  -- if repeating with till (t or T, inclusive = false) then search from the next character
+  -- returns nil if cancelled or char
+  char = char or vim.fn.nr2char(vim.fn.getchar())
+  repeating = repeating or false
+
+  if char == vim.fn.nr2char(27) then
+    -- escape
+    return nil
+  end
+
+  local line = vim.api.nvim_get_current_line()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+
+  -- find the count-th occurrence of the char in the line
+  local found
+  for _ = 1, vim.v.count1 do
+    if forward then
+      if not inclusive and repeating then
+        cursor[2] = cursor[2] + 1
+      end
+      found = line:find(char, cursor[2] + 2, true)
+    else
+      -- reverse find from the cursor position
+      if not inclusive and repeating then
+        cursor[2] = cursor[2] - 1
+      end
+
+      found = line:reverse():find(char, #line - cursor[2] + 1, true)
+      if found then
+        found = #line - found + 1
+      end
+    end
+
+    if not found then
+      return char
+    end
+
+    if forward then
+      if not inclusive then
+        found = found - 1
+      end
+    else
+      if not inclusive then
+        found = found + 1
+      end
+    end
+
+    cursor[2] = found - 1
+    repeating = true -- after the first iteration, search from the next character if not inclusive.
+  end
+
+  -- move to the found position
+  vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] })
+  return char
+end
+
+M.builtin_f = function()
+  local char = builtin_find("forward", "inclusive")
+  if builtin_find ~= nil then
+    M.last_move = { func = builtin_find, args = { "forward", "inclusive", char, "repeating" } }
+  end
+end
+
+M.builtin_F = function()
+  local char = builtin_find(not "forward", "inclusive")
+  if builtin_find ~= nil then
+    M.last_move = { func = builtin_find, args = { not "forward", "inclusive", char, "repeating" } }
+  end
+end
+
+M.builtin_t = function()
+  local char = builtin_find("forward", not "inclusive")
+  if builtin_find ~= nil then
+    M.last_move = { func = builtin_find, args = { "forward", not "inclusive", char, "repeating" } }
+  end
+end
+
+M.builtin_T = function()
+  local char = builtin_find(not "forward", not "inclusive")
+  if builtin_find ~= nil then
+    M.last_move = { func = builtin_find, args = { not "forward", not "inclusive", char, "repeating" } }
+  end
+end
+
+M.repeat_last_move = function()
+  if M.last_move then
+    M.last_move.func(unpack(M.last_move.args))
+  end
+end
+
+M.repeat_last_move_opposite = function()
+  if M.last_move then
+    local args = { unpack(M.last_move.args) } -- copy the table
+    if M.last_move.func == move then
+      args[2] = not args[2] -- reverse the direction
+    else
+      -- builtin_find
+      args[1] = not args[1] -- reverse the direction
+    end
+    M.last_move.func(unpack(args))
+  end
+end
+
+M.repeat_last_move_next = function()
+  if M.last_move then
+    local args = { unpack(M.last_move.args) } -- copy the table
+    if M.last_move.func == move then
+      args[2] = "forward" -- set the direction to forward
+    else
+      -- builtin_find
+      args[1] = "forward" -- set the direction to forward
+    end
+    M.last_move.func(unpack(args))
+  end
+end
+
+M.repeat_last_move_previous = function()
+  if M.last_move then
+    local args = { unpack(M.last_move.args) } -- copy the table
+    if M.last_move.func == move then
+      args[2] = not "forward" -- set the direction to backward
+    else
+      -- builtin_find
+      args[1] = not "forward" -- set the direction to backward
+    end
+    M.last_move.func(unpack(args))
+  end
 end
 
 local nxo_mode_functions = { "goto_next_start", "goto_next_end", "goto_previous_start", "goto_previous_end" }
@@ -115,6 +260,30 @@ M.commands = {
       "-nargs=1",
       "-complete=custom,nvim_treesitter_textobjects#available_textobjects",
     },
+  },
+  TSTextobjectRepeatLastMove = {
+    run = M.repeat_last_move,
+  },
+  TSTextobjectRepeatLastMoveOpposite = {
+    run = M.repeat_last_move_opposite,
+  },
+  TSTextobjectRepeatLastMoveNext = {
+    run = M.repeat_last_move_next,
+  },
+  TSTextobjectRepeatLastMovePrevious = {
+    run = M.repeat_last_move_previous,
+  },
+  TSTextobjectBuiltinf = {
+    run = M.builtin_f,
+  },
+  TSTextobjectBuiltinF = {
+    run = M.builtin_F,
+  },
+  TSTextobjectBuiltint = {
+    run = M.builtin_t,
+  },
+  TSTextobjectBuiltinT = {
+    run = M.builtin_T,
   },
 }
 

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -17,7 +17,7 @@ M.last_move = nil
 -- move_fn's first argument must be a boolean indicating whether to move forward (true) or backward (false)
 -- Then you can use four functions:
 --   M.repeat_last_move
---   M.repeat_last_move_oppisite
+--   M.repeat_last_move_opposite
 --   M.repeat_last_move_next
 --   M.repeat_last_move_previous
 function M.make_repeatable_move(move_fn)

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -103,23 +103,51 @@ end
 local move_repeatable = repeatable_move.make_repeatable_move(move)
 
 M.goto_next_start = function(query_strings_regex, query_group)
-  move_repeatable { forward = true, start = true, query_strings_regex = query_strings_regex, query_group = query_group }
+  move_repeatable {
+    forward = true,
+    start = true,
+    query_strings_regex = query_strings_regex,
+    query_group = query_group,
+  }
 end
 M.goto_next_end = function(query_strings_regex, query_group)
-  move_repeatable { forward = true, start = true, query_strings_regex = query_strings_regex, query_group = query_group }
+  move_repeatable {
+    forward = true,
+    start = false,
+    query_strings_regex = query_strings_regex,
+    query_group = query_group,
+  }
 end
 M.goto_previous_start = function(query_strings_regex, query_group)
-  move_repeatable { forward = false, start = true, query_strings_regex = query_strings_regex, query_group = query_group }
+  move_repeatable {
+    forward = false,
+    start = true,
+    query_strings_regex = query_strings_regex,
+    query_group = query_group,
+  }
 end
 M.goto_previous_end = function(query_strings_regex, query_group)
-  move_repeatable { forward = false, start = false, query_strings_regex = query_strings_regex, query_group = query_group }
+  move_repeatable {
+    forward = false,
+    start = false,
+    query_strings_regex = query_strings_regex,
+    query_group = query_group,
+  }
 end
 
 M.goto_next = function(query_strings_regex, query_group)
-  move_repeatable { forward = true, query_strings_regex = query_strings_regex, query_group = query_group }
+  move_repeatable {
+    forward = true,
+    query_strings_regex = query_strings_regex,
+    query_group = query_group,
+  }
 end
 M.goto_previous = function(query_strings_regex, query_group)
-  move_repeatable { forward = false, query_strings_regex = query_strings_regex, query_group = query_group }
+  move_repeatable {
+    forward = false,
+    query_strings_regex = query_strings_regex,
+    query_group = query_group,
+  }
 end
 
 local nxo_mode_functions = {

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -95,13 +95,14 @@ M.goto_previous_end = function(query_strings)
 end
 
 -- implements naive f, F, t, T with repeat support
-local function builtin_find(forward, inclusive, char, repeating)
+local function builtin_find(forward, inclusive, char, repeating, winid)
   -- forward = true -> f, t
   -- inclusive = false -> t, T
   -- if repeating with till (t or T, inclusive = false) then search from the next character
   -- returns nil if cancelled or char
   char = char or vim.fn.nr2char(vim.fn.getchar())
   repeating = repeating or false
+  winid = winid or vim.api.nvim_get_current_win()
 
   if char == vim.fn.nr2char(27) then
     -- escape
@@ -109,7 +110,7 @@ local function builtin_find(forward, inclusive, char, repeating)
   end
 
   local line = vim.api.nvim_get_current_line()
-  local cursor = vim.api.nvim_win_get_cursor(0)
+  local cursor = vim.api.nvim_win_get_cursor(winid)
 
   -- find the count-th occurrence of the char in the line
   local found
@@ -150,7 +151,7 @@ local function builtin_find(forward, inclusive, char, repeating)
   end
 
   -- move to the found position
-  vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] })
+  vim.api.nvim_win_set_cursor(winid, { cursor[1], cursor[2] })
   return char
 end
 

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -27,6 +27,31 @@ function M.make_repeatable_move(move_fn)
   end
 end
 
+-- Alternatively, you can use this function
+-- Returns:
+--   repeatable_forward_move_fn, repeatable_backward_move_fn
+function M.make_repeatable_move_pair(forward_move_fn, backward_move_fn)
+  local general_repeatable_move_fn = function(forward, ...)
+    if forward then
+      forward_move_fn(...)
+    else
+      backward_move_fn(...)
+    end
+  end
+
+  local repeatable_forward_move_fn = function(...)
+    M.last_move = { func = general_repeatable_move_fn, args = { true, ... } }
+    forward_move_fn(...)
+  end
+
+  local repeatable_backward_move_fn = function(...)
+    M.last_move = { func = general_repeatable_move_fn, args = { false, ... } }
+    backward_move_fn(...)
+  end
+
+  return repeatable_forward_move_fn, repeatable_backward_move_fn
+end
+
 local function move(forward, query_strings, start, winid)
   query_strings = shared.make_query_strings_table(query_strings)
   winid = winid or vim.api.nvim_get_current_win()

--- a/lua/nvim-treesitter/textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter/textobjects/repeatable_move.lua
@@ -87,34 +87,39 @@ M.make_repeatable_move_pair = function(forward_move_fn, backward_move_fn)
   return repeatable_forward_move_fn, repeatable_backward_move_fn
 end
 
-M.repeat_last_move = function()
+M.repeat_last_move = function(opts_extend)
   if M.last_move then
-    M.last_move.func(M.last_move.opts, unpack(M.last_move.additional_args))
+    local opts
+    if opts_extend ~= nil then
+      if type(opts_extend) ~= "table" then
+        vim.notify(
+          "nvim-treesitter-textobjects: opts_extend has to be a table but got " .. vim.inspect(opts_extend),
+          vim.log.levels.ERROR
+        )
+        return false
+      end
+
+      opts = vim.tbl_deep_extend("force", {}, M.last_move.opts, opts_extend)
+    else
+      opts = M.last_move.opts
+    end
+
+    M.last_move.func(opts, unpack(M.last_move.additional_args))
+    return true
   end
+  return false
 end
 
 M.repeat_last_move_opposite = function()
-  if M.last_move then
-    local opts = vim.deepcopy(M.last_move.opts)
-    opts.forward = not opts.forward
-    M.last_move.func(opts, unpack(M.last_move.additional_args))
-  end
+  return M.repeat_last_move { forward = not M.last_move.opts.forward }
 end
 
 M.repeat_last_move_next = function()
-  if M.last_move then
-    local opts = vim.deepcopy(M.last_move.opts)
-    opts.forward = true
-    M.last_move.func(opts, unpack(M.last_move.additional_args))
-  end
+  return M.repeat_last_move { forward = true }
 end
 
 M.repeat_last_move_previous = function()
-  if M.last_move then
-    local opts = vim.deepcopy(M.last_move.opts)
-    opts.forward = false
-    M.last_move.func(opts, unpack(M.last_move.additional_args))
-  end
+  return M.repeat_last_move { forward = false }
 end
 
 -- implements naive f, F, t, T with repeat support

--- a/lua/nvim-treesitter/textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter/textobjects/repeatable_move.lua
@@ -24,7 +24,8 @@ M.clear_last_move = function()
   M.last_move = nil
 end
 
--- move_fn's first argument must be a table of options, and it should include a `forward` boolean indicating whether to move forward (true) or backward (false)
+-- move_fn's first argument must be a table of options, and it should include a `forward` boolean
+-- indicating whether to move forward (true) or backward (false)
 M.set_last_move = function(move_fn, opts, ...)
   if type(move_fn) ~= "function" then
     vim.notify(

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -38,7 +38,7 @@ end
 
 local normal_mode_functions = { "swap_next", "swap_previous" }
 
-M.attach = attach.make_attach(normal_mode_functions, "swap", "n", { repeatable = true })
+M.attach = attach.make_attach(normal_mode_functions, "swap", "n", { dot_repeatable = true })
 M.detach = attach.make_detach(normal_mode_functions, "swap", "n")
 
 M.commands = {


### PR DESCRIPTION
Implements #340 

Supports normal, visual and operator-pending modes, `v:count1` count repeat, and optionally builtin f, F, t, T mappings if you want to use the same `;` bindings.

```lua
local tstextobj_move = require "nvim-treesitter.textobjects.move"

-- Repeat movement with ; and ,
-- ensure ; goes forward and , goes backward
vim.keymap.set({ "n", "x", "o" }, ";", tstextobj_move.repeat_last_move_next)
vim.keymap.set({ "n", "x", "o" }, ",", tstextobj_move.repeat_last_move_previous)

-- vim way: ; goes to the direction you were moving.
-- vim.keymap.set({ "n", "x", "o" }, ";", tstextobj_move.repeat_last_move)
-- vim.keymap.set({ "n", "x", "o" }, ",", tstextobj_move.repeat_last_move_opposite)

-- Make builtin f, F, t, T also repeatable with ; and ,
vim.keymap.set({ "n", "x", "o" }, "f", tstextobj_move.builtin_f)
vim.keymap.set({ "n", "x", "o" }, "F", tstextobj_move.builtin_F)
vim.keymap.set({ "n", "x", "o" }, "t", tstextobj_move.builtin_t)
vim.keymap.set({ "n", "x", "o" }, "T", tstextobj_move.builtin_T)
```