### PR TITLE
Gradual movement (regex query string, goto_next and goto_previous without specifying start / end)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ require'nvim-treesitter.configs'.setup {
       goto_next_start = {
         ["]m"] = "@function.outer",
         ["]]"] = { query = "@class.outer", desc = "Next class start" },
+        --
+        -- You can use regex matching and/or pass a list in a "query" key to group multiple queires.
+        ["]o"] = "@loop.*",
+        -- ["]o"] = { query = { "@loop.inner", "@loop.outer" } }
+        --
+        -- You can pass a query group to use query from `queries/<lang>/<query_group>.scm file in your runtime path.
+        -- Below example nvim-treesitter's `locals.scm` and `folds.scm`. They also provide highlights.scm and indent.scm.
+        ["]s"] = { query = "@scope", query_group = "locals", desc = "Next scope" },
+        ["]z"] = { query = "@fold", query_group = "folds", desc = "Next fold" },
       },
       goto_next_end = {
         ["]M"] = "@function.outer",
@@ -123,6 +132,15 @@ require'nvim-treesitter.configs'.setup {
         ["[M"] = "@function.outer",
         ["[]"] = "@class.outer",
       },
+      -- Below will go to either the start or the end, whichever is closer.
+      -- Use if you want more granular movements
+      -- Make it even more gradual by adding multiple queries and regex.
+      goto_next = {
+        ["]d"] = "@conditional.outer",
+      },
+      goto_previous = {
+        ["[d"] = "@conditional.outer",
+      }
     },
   },
 }

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -25,18 +25,20 @@ function M.make_attach(normal_mode_functions, submodule, keymap_modes, opts)
     for _, function_call in pairs(normal_mode_functions) do
       local function_description = function_call:gsub("_", " "):gsub("^%l", string.upper)
       for mapping, query_metadata in pairs(config[function_call] or {}) do
-        local mapping_description, query
+        local mapping_description, query, query_group
 
         if type(query_metadata) == "table" then
           query = query_metadata.query
+          query_group = query_metadata.query_group
           mapping_description = query_metadata.desc
         else
           query = query_metadata
+          query_group = "textobjects"
           mapping_description = function_description .. " " .. query_metadata
         end
 
         local fn = function()
-          require("nvim-treesitter.textobjects." .. submodule)[function_call](query)
+          require("nvim-treesitter.textobjects." .. submodule)[function_call](query, query_group)
         end
         if opts.repeatable then
           fn = make_repeatable(fn)

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -29,7 +29,7 @@ function M.make_attach(normal_mode_functions, submodule, keymap_modes, opts)
 
         if type(query_metadata) == "table" then
           query = query_metadata.query
-          query_group = query_metadata.query_group
+          query_group = query_metadata.query_group or "textobjects"
           mapping_description = query_metadata.desc
         else
           query = query_metadata

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -81,7 +81,7 @@ function M.make_preview_location_callback(textobject, context)
     vim.fn.bufload(buf)
 
     local _, textobject_at_definition =
-      shared.textobject_at_point(textobject, { range.start.line + 1, range.start.character }, buf)
+      shared.textobject_at_point(textobject, "textobjects", { range.start.line + 1, range.start.character }, buf)
 
     if textobject_at_definition then
       context = textobject_at_definition

--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -57,8 +57,9 @@ function M.preview_location(location, context)
   return preview_buf, preview_win
 end
 
-function M.make_preview_location_callback(textobject, context)
-  local context = context or 0
+function M.make_preview_location_callback(query_string, query_group, context)
+  query_group = query_group or "textobjects"
+  context = context or 0
   local callback = function(err, method, result)
     if err then
       error(tostring(err))
@@ -81,7 +82,7 @@ function M.make_preview_location_callback(textobject, context)
     vim.fn.bufload(buf)
 
     local _, textobject_at_definition =
-      shared.textobject_at_point(textobject, "textobjects", { range.start.line + 1, range.start.character }, buf)
+      shared.textobject_at_point(query_string, query_group, { range.start.line + 1, range.start.character }, buf)
 
     if textobject_at_definition then
       context = textobject_at_definition
@@ -101,13 +102,19 @@ function M.make_preview_location_callback(textobject, context)
   return vim.schedule_wrap(signature_handler)
 end
 
-function M.peek_definition_code(textobject, lsp_request, context)
+function M.peek_definition_code(query_string, query_group, lsp_request, context)
+  query_group = query_group or "textobjects"
   lsp_request = lsp_request or "textDocument/definition"
   if vim.tbl_contains(vim.api.nvim_list_wins(), floating_win) then
     vim.api.nvim_set_current_win(floating_win)
   else
     local params = vim.lsp.util.make_position_params()
-    return vim.lsp.buf_request(0, lsp_request, params, M.make_preview_location_callback(textobject, context))
+    return vim.lsp.buf_request(
+      0,
+      lsp_request,
+      params,
+      M.make_preview_location_callback(query_string, query_group, context)
+    )
   end
 end
 

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -24,17 +24,8 @@ local function move(query_strings_regex, query_group, forward, start, winid)
   end
   winid = winid or vim.api.nvim_get_current_win()
   local bufnr = vim.api.nvim_win_get_buf(winid)
-
-  -- Get query strings from regex
-  local available_textobjects = shared.available_textobjects(parsers.get_buf_lang(bufnr), query_group)
-  local query_strings = {}
-  for _, query_string_regex in ipairs(query_strings_regex) do
-    for _, available_textobject in ipairs(available_textobjects) do
-      if string.match("@" .. available_textobject, query_string_regex) then
-        table.insert(query_strings, "@" .. available_textobject)
-      end
-    end
-  end
+  local query_strings =
+    shared.get_query_strings_from_regex(query_strings_regex, query_group, parsers.get_buf_lang(bufnr))
 
   local config = configs.get_module "textobjects.move"
 

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -87,7 +87,6 @@ local function move(query_strings_regex, forward, start, winid)
 
         if current_match then
           local score = scoring_function(start_, current_match)
-          print(score)
           if not best_match then
             best_match = current_match
             best_score = score

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -3,21 +3,61 @@ local attach = require "nvim-treesitter.textobjects.attach"
 local shared = require "nvim-treesitter.textobjects.shared"
 local queries = require "nvim-treesitter.query"
 local configs = require "nvim-treesitter.configs"
+local parsers = require "nvim-treesitter.parsers"
 
 local M = {}
 
-local function move(query_strings, forward, start, winid)
-  query_strings = shared.make_query_strings_table(query_strings)
+local function move(query_strings_regex, forward, start, winid)
+  -- start: bool or nil. If true, choose the start of the node, and false is for the end.
+  -- If nil, it considers both and chooses the closer side.
+  query_strings_regex = shared.make_query_strings_table(query_strings_regex)
+  local starts
+  if start == nil then
+    starts = { true, false }
+  else
+    if start then
+      starts = { true }
+    else
+      starts = { false }
+    end
+  end
   winid = winid or vim.api.nvim_get_current_win()
   local bufnr = vim.api.nvim_win_get_buf(winid)
 
+  -- Get query strings from regex
+  local available_textobjects = shared.available_textobjects(parsers.get_buf_lang(bufnr))
+  local query_strings = {}
+  for _, query_string_regex in ipairs(query_strings_regex) do
+    for _, available_textobject in ipairs(available_textobjects) do
+      if string.match("@" .. available_textobject, query_string_regex) then
+        table.insert(query_strings, "@" .. available_textobject)
+      end
+    end
+  end
+
   local config = configs.get_module "textobjects.move"
-  local function filter_function(match)
+
+  -- score is a byte position.
+  local function scoring_function(start_, match)
+    local score, _
+    if start_ then
+      _, _, score = match.node:start()
+    else
+      _, _, score = match.node:end_()
+    end
+    if forward then
+      return -score
+    else
+      return score
+    end
+  end
+
+  local function filter_function(start_, match)
     local range = { match.node:range() }
     local row, col = unpack(vim.api.nvim_win_get_cursor(winid))
     row = row - 1 -- nvim_win_get_cursor is (1,0)-indexed
 
-    if not start then
+    if not start_ then
       if range[4] == 0 then
         range[1] = range[3] - 1
         range[2] = range[4]
@@ -33,39 +73,35 @@ local function move(query_strings, forward, start, winid)
     end
   end
 
-  local function scoring_function(match)
-    local score, _
-    if start then
-      _, _, score = match.node:start()
-    else
-      _, _, score = match.node:end_()
-    end
-    if forward then
-      return -score
-    else
-      return score
-    end
-  end
-
   for _ = 1, vim.v.count1 do
     local best_match
     local best_score
+    local best_start
     for _, query_string in ipairs(query_strings) do
-      local current_match =
-        queries.find_best_match(bufnr, query_string, "textobjects", filter_function, scoring_function)
-      if current_match then
-        local score = scoring_function(current_match)
-        if not best_match then
-          best_match = current_match
-          best_score = score
-        end
-        if score > best_score then
-          best_match = current_match
-          best_score = score
+      for _, start_ in ipairs(starts) do
+        local current_match = queries.find_best_match(bufnr, query_string, "textobjects", function(match)
+          return filter_function(start_, match)
+        end, function(match)
+          return scoring_function(start_, match)
+        end)
+
+        if current_match then
+          local score = scoring_function(start_, current_match)
+          print(score)
+          if not best_match then
+            best_match = current_match
+            best_score = score
+            best_start = start_
+          end
+          if score > best_score then
+            best_match = current_match
+            best_score = score
+            best_start = start_
+          end
         end
       end
     end
-    ts_utils.goto_node(best_match and best_match.node, not start, not config.set_jumps)
+    ts_utils.goto_node(best_match and best_match.node, not best_start, not config.set_jumps)
   end
 end
 
@@ -82,7 +118,21 @@ M.goto_previous_end = function(query_strings)
   move(query_strings, not "forward", not "start")
 end
 
-local nxo_mode_functions = { "goto_next_start", "goto_next_end", "goto_previous_start", "goto_previous_end" }
+M.goto_next = function(query_strings)
+  move(query_strings, "forward")
+end
+M.goto_previous = function(query_strings)
+  move(query_strings, not "forward")
+end
+
+local nxo_mode_functions = {
+  "goto_next_start",
+  "goto_next_end",
+  "goto_previous_start",
+  "goto_previous_end",
+  "goto_next",
+  "goto_previous",
+}
 
 M.attach = attach.make_attach(nxo_mode_functions, "move", { "n", "x", "o" })
 M.detach = attach.make_detach(nxo_mode_functions, "move", { "n", "x", "o" })

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -7,10 +7,11 @@ local parsers = require "nvim-treesitter.parsers"
 
 local M = {}
 
-local function move(query_strings_regex, forward, start, winid)
+local function move(query_strings_regex, query_group, forward, start, winid)
   -- start: bool or nil. If true, choose the start of the node, and false is for the end.
   -- If nil, it considers both and chooses the closer side.
   query_strings_regex = shared.make_query_strings_table(query_strings_regex)
+  query_group = query_group or "textobjects"
   local starts
   if start == nil then
     starts = { true, false }
@@ -25,7 +26,7 @@ local function move(query_strings_regex, forward, start, winid)
   local bufnr = vim.api.nvim_win_get_buf(winid)
 
   -- Get query strings from regex
-  local available_textobjects = shared.available_textobjects(parsers.get_buf_lang(bufnr))
+  local available_textobjects = shared.available_textobjects(parsers.get_buf_lang(bufnr), query_group)
   local query_strings = {}
   for _, query_string_regex in ipairs(query_strings_regex) do
     for _, available_textobject in ipairs(available_textobjects) do
@@ -79,7 +80,7 @@ local function move(query_strings_regex, forward, start, winid)
     local best_start
     for _, query_string in ipairs(query_strings) do
       for _, start_ in ipairs(starts) do
-        local current_match = queries.find_best_match(bufnr, query_string, "textobjects", function(match)
+        local current_match = queries.find_best_match(bufnr, query_string, query_group, function(match)
           return filter_function(start_, match)
         end, function(match)
           return scoring_function(start_, match)
@@ -104,24 +105,25 @@ local function move(query_strings_regex, forward, start, winid)
   end
 end
 
-M.goto_next_start = function(query_strings)
-  move(query_strings, "forward", "start")
+M.goto_next_start = function(query_strings, query_group)
+  query_group = query_group or "textobjects"
+  move(query_strings, query_group, "forward", "start")
 end
-M.goto_next_end = function(query_strings)
-  move(query_strings, "forward", not "start")
+M.goto_next_end = function(query_strings, query_group)
+  move(query_strings, query_group, "forward", not "start")
 end
-M.goto_previous_start = function(query_strings)
-  move(query_strings, not "forward", "start")
+M.goto_previous_start = function(query_strings, query_group)
+  move(query_strings, query_group, not "forward", "start")
 end
-M.goto_previous_end = function(query_strings)
-  move(query_strings, not "forward", not "start")
+M.goto_previous_end = function(query_strings, query_group)
+  move(query_strings, query_group, not "forward", not "start")
 end
 
-M.goto_next = function(query_strings)
-  move(query_strings, "forward")
+M.goto_next = function(query_strings, query_group)
+  move(query_strings, query_group, "forward")
 end
-M.goto_previous = function(query_strings)
-  move(query_strings, not "forward")
+M.goto_previous = function(query_strings, query_group)
+  move(query_strings, query_group, not "forward")
 end
 
 local nxo_mode_functions = {

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -95,17 +95,13 @@ local val_or_return = function(val, opts)
   end
 end
 
-function M.select_textobject(query_string, keymap_mode)
+function M.select_textobject(query_string, query_group, keymap_mode)
+  query_group = query_group or "textobjects"
   local lookahead = configs.get_module("textobjects.select").lookahead
   local lookbehind = configs.get_module("textobjects.select").lookbehind
   local surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
-  local bufnr, textobject = shared.textobject_at_point(
-    query_string,
-    "textobjects",
-    nil,
-    nil,
-    { lookahead = lookahead, lookbehind = lookbehind }
-  )
+  local bufnr, textobject =
+    shared.textobject_at_point(query_string, query_group, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
   if textobject then
     local selection_mode = M.detect_selection_mode(query_string, keymap_mode)
     if
@@ -150,33 +146,52 @@ function M.detect_selection_mode(query_string, keymap_mode)
 end
 
 function M.attach(bufnr, lang)
-  local buf = bufnr or api.nvim_get_current_buf()
+  bufnr = bufnr or api.nvim_get_current_buf()
   local config = configs.get_module "textobjects.select"
-  lang = lang or parsers.get_buf_lang(buf)
+  lang = lang or parsers.get_buf_lang(bufnr)
 
   for mapping, query in pairs(config.keymaps) do
-    local desc
+    local desc, query_string, query_group
     if type(query) == "table" then
       desc = query.desc
-      query = query.query
+      query_string = query.query
+      query_group = query.query_group or "textobjects"
+    else
+      query_string = query
+      query_group = "textobjects"
     end
     if not desc then
-      desc = "Select textobject " .. query
+      desc = "Select textobject " .. query_string
     end
-    if not queries.get_query(lang, "textobjects") then
-      query = nil
+
+    local available_textobjects = shared.available_textobjects(lang, query_group)
+    local available = false
+    for _, available_textobject in ipairs(available_textobjects) do
+      if "@" .. available_textobject == query_string then
+        available = true
+        break
+      end
     end
-    if query then
-      local cmd_o = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'o')<CR>"
-      local cmd_x = "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('" .. query .. "', 'x')<CR>"
-      vim.keymap.set({ "o" }, mapping, cmd_o, { buffer = buf, silent = true, remap = false, desc = desc })
-      vim.keymap.set({ "x" }, mapping, cmd_x, { buffer = buf, silent = true, remap = false, desc = desc })
+
+    if not available then
+      query_string = nil
+    end
+
+    if query_string then
+      local cmd_o = function()
+        M.select_textobject(query_string, query_group, "o")
+      end
+      local cmd_x = function()
+        M.select_textobject(query_string, query_group, "x")
+      end
+      vim.keymap.set({ "o" }, mapping, cmd_o, { buffer = bufnr, silent = true, remap = false, desc = desc })
+      vim.keymap.set({ "x" }, mapping, cmd_x, { buffer = bufnr, silent = true, remap = false, desc = desc })
     end
   end
 end
 
 function M.detach(bufnr)
-  local buf = bufnr or api.nvim_get_current_buf()
+  bufnr = bufnr or api.nvim_get_current_buf()
   local config = configs.get_module "textobjects.select"
   local lang = parsers.get_buf_lang(bufnr)
 
@@ -188,7 +203,7 @@ function M.detach(bufnr)
       query = query.query
     end
     if query then
-      vim.keymap.del({ "o", "x" }, mapping, { buffer = buf })
+      vim.keymap.del({ "o", "x" }, mapping, { buffer = bufnr })
     end
   end
 end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -99,8 +99,13 @@ function M.select_textobject(query_string, keymap_mode)
   local lookahead = configs.get_module("textobjects.select").lookahead
   local lookbehind = configs.get_module("textobjects.select").lookbehind
   local surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
-  local bufnr, textobject =
-    shared.textobject_at_point(query_string, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
+  local bufnr, textobject = shared.textobject_at_point(
+    query_string,
+    "textobjects",
+    nil,
+    nil,
+    { lookahead = lookahead, lookbehind = lookbehind }
+  )
   if textobject then
     local selection_mode = M.detect_selection_mode(query_string, keymap_mode)
     if

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -17,9 +17,10 @@ function M.make_query_strings_table(query_strings)
   return type(query_strings) == "string" and { query_strings } or query_strings
 end
 
-function M.available_textobjects(lang)
+function M.available_textobjects(lang, query_group)
   lang = lang or parsers.get_buf_lang()
-  local parsed_queries = queries.get_query(lang, "textobjects")
+  query_group = query_group or "textobjects"
+  local parsed_queries = queries.get_query(lang, query_group)
   if not parsed_queries then
     return {}
   end
@@ -43,7 +44,8 @@ function M.available_textobjects(lang)
   --}
 end
 
-function M.textobject_at_point(query_string, pos, bufnr, opts)
+function M.textobject_at_point(query_string, query_group, pos, bufnr, opts)
+  query_group = query_group or "textobjects"
   opts = opts or {}
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   local lang = parsers.get_buf_lang(bufnr)
@@ -57,7 +59,7 @@ function M.textobject_at_point(query_string, pos, bufnr, opts)
   if not string.match(query_string, "^@.*") then
     error 'Captures must start with "@"'
   end
-  local matches = queries.get_capture_matches_recursively(bufnr, query_string, "textobjects")
+  local matches = queries.get_capture_matches_recursively(bufnr, query_string, query_group)
 
   local match_length
   local smallest_range

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -17,6 +17,24 @@ function M.make_query_strings_table(query_strings)
   return type(query_strings) == "string" and { query_strings } or query_strings
 end
 
+-- Get query strings from regex
+function M.get_query_strings_from_regex(query_strings_regex, query_group, lang)
+  query_strings_regex = M.make_query_strings_table(query_strings_regex)
+  query_group = query_group or "textobjects"
+  lang = lang or parsers.get_buf_lang(0)
+  local available_textobjects = M.available_textobjects(lang, query_group)
+  local query_strings = {}
+  for _, query_string_regex in ipairs(query_strings_regex) do
+    for _, available_textobject in ipairs(available_textobjects) do
+      if string.match("@" .. available_textobject, query_string_regex) then
+        table.insert(query_strings, "@" .. available_textobject)
+      end
+    end
+  end
+
+  return query_strings
+end
+
 function M.available_textobjects(lang, query_group)
   lang = lang or parsers.get_buf_lang()
   query_group = query_group or "textobjects"
@@ -145,12 +163,14 @@ function M.textobject_at_point(query_string, query_group, pos, bufnr, opts)
   end
 end
 
-function M.get_adjacent(forward, node, query_string, same_parent, overlapping_range_ok, bufnr)
+function M.get_adjacent(forward, node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
+  query_group = query_group or "textobjects"
   local fn = forward and M.next_textobject or M.previous_textobject
-  return fn(node, query_string, same_parent, overlapping_range_ok, bufnr)
+  return fn(node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
 end
 
-function M.next_textobject(node, query_string, same_parent, overlapping_range_ok, bufnr)
+function M.next_textobject(node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
+  query_group = query_group or "textobjects"
   local node = node or ts_utils.get_node_at_cursor()
   local bufnr = bufnr or api.nvim_get_current_buf()
   if not node then
@@ -179,12 +199,13 @@ function M.next_textobject(node, query_string, same_parent, overlapping_range_ok
     return -node_start
   end
 
-  local next_node = queries.find_best_match(bufnr, query_string, "textobjects", filter_function, scoring_function)
+  local next_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
 
   return next_node and next_node.node
 end
 
-function M.previous_textobject(node, query_string, same_parent, overlapping_range_ok, bufnr)
+function M.previous_textobject(node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
+  query_group = query_group or "textobjects"
   local node = node or ts_utils.get_node_at_cursor()
   local bufnr = bufnr or api.nvim_get_current_buf()
   if not node then
@@ -213,7 +234,7 @@ function M.previous_textobject(node, query_string, same_parent, overlapping_rang
     return node_end
   end
 
-  local previous_node = queries.find_best_match(bufnr, query_string, "textobjects", filter_function, scoring_function)
+  local previous_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
 
   return previous_node and previous_node.node
 end

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -1,14 +1,19 @@
 local ts_utils = require "nvim-treesitter.ts_utils"
 local shared = require "nvim-treesitter.textobjects.shared"
 local attach = require "nvim-treesitter.textobjects.attach"
+local parsers = require "nvim-treesitter.parsers"
 
 local M = {}
 
-local function swap_textobject(query_strings, direction)
-  query_strings = shared.make_query_strings_table(query_strings)
+local function swap_textobject(query_strings_regex, query_group, direction)
+  query_strings_regex = shared.make_query_strings_table(query_strings_regex)
+  query_group = query_group or "textobjects"
+
+  local query_strings = shared.get_query_strings_from_regex(query_strings_regex, query_group)
+
   local bufnr, textobject_range, node, query_string
   for _, query_string_iter in ipairs(query_strings) do
-    bufnr, textobject_range, node = shared.textobject_at_point(query_string_iter)
+    bufnr, textobject_range, node = shared.textobject_at_point(query_string_iter, query_group)
     if node then
       query_string = query_string_iter
       break
@@ -23,17 +28,18 @@ local function swap_textobject(query_strings, direction)
   local same_parent = true
   for _ = 1, math.abs(direction), step do
     local forward = direction > 0
-    local adjacent = shared.get_adjacent(forward, node, query_string, same_parent, overlapping_range_ok, bufnr)
+    local adjacent =
+      shared.get_adjacent(forward, node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
     ts_utils.swap_nodes(textobject_range, adjacent, bufnr, "yes, set cursor!")
   end
 end
 
-function M.swap_next(query_string)
-  swap_textobject(query_string, 1)
+function M.swap_next(query_strings_regex, query_group)
+  swap_textobject(query_strings_regex, query_group, 1)
 end
 
-function M.swap_previous(query_string)
-  swap_textobject(query_string, -1)
+function M.swap_previous(query_strings_regex, query_group)
+  swap_textobject(query_strings_regex, query_group, -1)
 end
 
 local normal_mode_functions = { "swap_next", "swap_previous" }

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -1,7 +1,6 @@
 local ts_utils = require "nvim-treesitter.ts_utils"
 local shared = require "nvim-treesitter.textobjects.shared"
 local attach = require "nvim-treesitter.textobjects.attach"
-local parsers = require "nvim-treesitter.parsers"
 
 local M = {}
 


### PR DESCRIPTION
Before merging #359 I wanted to show you this.

At the moment, my keymaps are quite polluted.

```lua
      goto_next_start = {
        ["]m"] = "@function.outer",
        ["]f"] = "@call.outer",
        ["]d"] = "@conditional.outer",
        ["]o"] = "@loop.outer",
        ["]s"] = "@statement.outer",
        ["]a"] = "@parameter.outer",
        ["]c"] = "@comment.outer",
        ["]b"] = "@block.outer",
        ["]l"] = { query = "@class.outer", desc = "next class start" },
        ["]]m"] = "@function.inner",
        ["]]f"] = "@call.inner",
        ["]]d"] = "@conditional.inner",
        ["]]o"] = "@loop.inner",
        ["]]a"] = "@parameter.inner",
        ["]]b"] = "@block.inner",
        ["]]l"] = { query = "@class.inner", desc = "next class start inner" },
      },
      goto_next_end = {
        ["]M"] = "@function.outer",
        ["]F"] = "@call.outer",
        ["]D"] = "@conditional.outer",
        ["]O"] = "@loop.outer",
        ["]S"] = "@statement.outer",
        ["]A"] = "@parameter.outer",
        ["]C"] = "@comment.outer",
        ["]B"] = "@block.outer",
        ["]L"] = "@class.outer",
        ["]]M"] = "@function.inner",
        ["]]F"] = "@call.inner",
        ["]]D"] = "@conditional.inner",
        ["]]O"] = "@loop.inner",
        ["]]A"] = "@parameter.inner",
        ["]]B"] = "@block.inner",
        ["]]L"] = "@class.inner",
      },
      goto_previous_start = {
        ["[m"] = "@function.outer",
        ["[f"] = "@call.outer",
        ["[d"] = "@conditional.outer",
        ["[o"] = "@loop.outer",
        ["[s"] = "@statement.outer",
        ["[a"] = "@parameter.outer",
        ["[c"] = "@comment.outer",
        ["[b"] = "@block.outer",
        ["[l"] = "@class.outer",
        ["[[m"] = "@function.inner",
        ["[[f"] = "@call.inner",
        ["[[d"] = "@conditional.inner",
        ["[[o"] = "@loop.inner",
        ["[[a"] = "@parameter.inner",
        ["[[b"] = "@block.inner",
        ["[[l"] = "@class.inner",
      },
      goto_previous_end = {
        ["[M"] = "@function.outer",
        ["[F"] = "@call.outer",
        ["[D"] = "@conditional.outer",
        ["[O"] = "@loop.outer",
        ["[S"] = "@statement.outer",
        ["[A"] = "@parameter.outer",
        ["[C"] = "@comment.outer",
        ["[B"] = "@block.outer",
        ["[L"] = "@class.outer",
        ["[[M"] = "@function.inner",
        ["[[F"] = "@call.inner",
        ["[[D"] = "@conditional.inner",
        ["[[O"] = "@loop.inner",
        ["[[A"] = "@parameter.inner",
        ["[[B"] = "@block.inner",
        ["[[L"] = "@class.inner",
      },
```

This patch enables you to group things together if you wish.  
```lua
      goto_next = {
        ["]m"] = "@function.*",
        ["]f"] = "@call.*",
        ["]o"] = { query = { "@loop.*", "@conditional.*" }, desc = "Next loop or conditional" },
        ["]s"] = "@statement.*",
        ["]a"] = "@parameter.*",
        ["]c"] = "@comment.*",
        ["]b"] = "@block.*",
        ["]l"] = { query = "@class.*", desc = "next class start/end" },
      },
      goto_previous = {
        ["[m"] = "@function.*",
        ["[f"] = "@call.*",
        ["[o"] = { query = { "@loop.*", "@conditional.*" }, desc = "Previous loop or conditional" },
        ["[s"] = "@statement.*",
        ["[a"] = "@parameter.*",
        ["[c"] = "@comment.*",
        ["[b"] = "@block.*",
        ["[l"] = { query = "@class.*", desc = "previous class start/end" },
      },
```

(I just noticed that you can already add multiple queries, however it isn't documented)  

Along with the power of repeatable movements, for some people it may be a good bonus as they can go to the right part they want without going for a complicated keymapping.

The regex queries are supported in the original `goto_next_start` etc. as well.  
It will stay mostly compatible with the previous setup, except that now the dot will match any character. If you have a custom query named `@functionQinner` then it will be matched with `@function.inner`