### PR TITLE
different logic for detaching keymaps (remember attached keymaps)

### DIFF
--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -119,7 +119,7 @@ function M.peek_definition_code(query_string, query_group, lsp_request, context)
 end
 
 M.attach = attach.make_attach(nx_mode_functions, "lsp_interop", { "n", "x" })
-M.detach = attach.make_detach(nx_mode_functions, "lsp_interop", { "n", "x" })
+M.detach = attach.make_detach "lsp_interop"
 M.commands = {
   TSTextobjectPeekDefinitionCode = {
     run = M.peek_definition_code,

--- a/lua/nvim-treesitter/textobjects/move.lua
+++ b/lua/nvim-treesitter/textobjects/move.lua
@@ -160,7 +160,7 @@ local nxo_mode_functions = {
 }
 
 M.attach = attach.make_attach(nxo_mode_functions, "move", { "n", "x", "o" })
-M.detach = attach.make_detach(nxo_mode_functions, "move", { "n", "x", "o" })
+M.detach = attach.make_detach "move"
 
 M.commands = {
   TSTextobjectGotoNextStart = {

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -44,7 +44,7 @@ end
 local normal_mode_functions = { "swap_next", "swap_previous" }
 
 M.attach = attach.make_attach(normal_mode_functions, "swap", "n", { dot_repeatable = true })
-M.detach = attach.make_detach(normal_mode_functions, "swap", "n")
+M.detach = attach.make_detach "swap"
 
 M.commands = {
   TSTextobjectSwapNext = {


### PR DESCRIPTION
Since #360 there is a new logic to adding keymaps because we allowed to set queries from another group. However, in detaching it doesn't consider the logic the same way.  

I think it makes more sense to remember the successful keymaps per buffer and use them for detaching. Also, added pcall to fallback silently if unsetting keymap fails.

The issue seems to have started happening in #362 and although it's been fixed for some people, it is still a problem for others (see comments from the issue below).