### PR TITLE
feat: add textobject for number literals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ Some nodes only have one type:
 @comment.outer
 @statement.outer
 @scopename.inner
+@number.inner
 ```
 ### Automatic README Generation
 

--- a/queries/bash/textobjects.scm
+++ b/queries/bash/textobjects.scm
@@ -17,3 +17,6 @@
 (comment) @comment.outer
 
 (regex) @regex.inner
+
+((word) @number.inner
+ (#lua-match? @number.inner "^[0-9]+$"))

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -78,3 +78,5 @@
 ((argument_list
   . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+(number_literal) @number.inner

--- a/queries/css/textobjects.scm
+++ b/queries/css/textobjects.scm
@@ -1,0 +1,5 @@
+[
+  (integer_value)
+  (float_value)
+  (color_value)
+] @number.inner

--- a/queries/dockerfile/textobjects.scm
+++ b/queries/dockerfile/textobjects.scm
@@ -1,0 +1,2 @@
+(expose_instruction
+  (expose_port) @number.inner)

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -105,3 +105,6 @@
 
 ;; regex
 (regex (regex_pattern) @regex.inner) @regex.outer
+
+;; number
+(number) @number.inner

--- a/queries/java/textobjects.scm
+++ b/queries/java/textobjects.scm
@@ -68,3 +68,11 @@
   (line_comment)
   (block_comment)
 ] @comment.outer
+
+[
+  (decimal_integer_literal)
+  (decimal_floating_point_literal)
+  (hex_integer_literal)
+  (binary_integer_literal)
+  (octal_integer_literal)
+] @number.inner

--- a/queries/kotlin/textobjects.scm
+++ b/queries/kotlin/textobjects.scm
@@ -1,0 +1,4 @@
+[
+  (integer_literal)
+  (real_literal)
+] @number.inner

--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -90,6 +90,9 @@
   . (_) @parameter.inner
  (#make-range! "parameter.outer" @_start @parameter.inner))
 
+; number
+(number) @number.inner
+
 ; scopename
 
 ; statement

--- a/queries/nix/textobjects.scm
+++ b/queries/nix/textobjects.scm
@@ -25,3 +25,8 @@
 (if_expression
   (_) @conditional.inner
 ) @conditional.outer
+
+[
+  (integer_expression)
+  (float_expression)
+] @number.inner

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -159,4 +159,9 @@
   )
   (#make-range! "parameter.outer" @_start @parameter.inner))
 
+[
+  (integer)
+  (float)
+] @number.inner
+
 ; TODO: exclude comments using the future negate syntax from tree-sitter

--- a/queries/r/textobjects.scm
+++ b/queries/r/textobjects.scm
@@ -81,3 +81,6 @@
   . ","? @_end
   )
   (#make-range! "parameter.outer" @parameter.inner @_end))
+
+; number
+(float) @number.inner

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -158,3 +158,8 @@
 ((type_arguments
   . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+[
+  (integer_literal)
+  (float_literal)
+] @number.inner

--- a/queries/scss/textobjects.scm
+++ b/queries/scss/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: css

--- a/queries/toml/textobjects.scm
+++ b/queries/toml/textobjects.scm
@@ -1,0 +1,4 @@
+[
+  (integer)
+  (float)
+] @number.inner

--- a/queries/vim/textobjects.scm
+++ b/queries/vim/textobjects.scm
@@ -22,3 +22,8 @@
 ((syntax_statement
    (pattern) @regex.inner @regex.outer)
  (#offset! @regex.outer 0 -1 0 1))
+
+[
+  (integer_literal)
+  (float_literal)
+] @number.inner

--- a/queries/yaml/textobjects.scm
+++ b/queries/yaml/textobjects.scm
@@ -1,0 +1,4 @@
+[
+  (integer_scalar)
+  (float_scalar)
+] @number.inner


### PR DESCRIPTION
Because floating-point numbers and CSS colors can't be selected with `iw`.