### PR TITLE
Add tests, Make builtin find consistent (when t and repeating)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,59 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'master'
+
+# Cancel any in-progress CI runs for a PR if it is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  check_compilation:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        cc: [gcc]
+
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Test Dependencies
+        run: |
+          mkdir -p ~/.local/share/nvim/site/pack/ci/opt
+          cd ~/.local/share/nvim/site/pack/ci/opt
+          git clone https://github.com/nvim-lua/plenary.nvim
+          git clone https://github.com/nvim-treesitter/nvim-treesitter
+      - name: Install and prepare Neovim
+        env:
+          NVIM_TAG: stable
+          TREE_SITTER_CLI_TAG: v0.20.6
+        run: |
+          bash ./scripts/ci-install-${{ matrix.os }}.sh
+      - name: Setup Parsers Cache
+        id: parsers-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./parser/
+            ~/AppData/Local/nvim/pack/nvim-treesitter/start/nvim-treesitter/parser/
+          key: ${{ matrix.os }}-${{ matrix.cc }}-parsers-v1-${{ hashFiles('./lockfile.json', './lua/nvim-treesitter/parsers.lua', './lua/nvim-treesitter/install.lua', './lua/nvim-treesitter/shell_selectors.lua') }}
+
+      - name: Compile parsers Unix like
+        if: ${{ matrix.os != 'windows-latest' && steps.parsers-cache.outputs.cache-hit != 'true' }}
+        run: |
+          nvim --headless -c "TSInstallSync all" -c "q"
+      - name: Tests
+        run: PATH=/usr/local/bin:$PATH ./scripts/run_tests.sh

--- a/lua/nvim-treesitter/textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter/textobjects/repeatable_move.lua
@@ -143,9 +143,18 @@ local function builtin_find(opts)
   local line = vim.api.nvim_get_current_line()
   local cursor = vim.api.nvim_win_get_cursor(winid)
 
+  -- count works like this with builtin vim motions.
+  -- weird, but we're matching the behaviour
+  local count
+  if not inclusive and repeating then
+    count = math.max(vim.v.count1 - 1, 1)
+  else
+    count = vim.v.count1
+  end
+
   -- find the count-th occurrence of the char in the line
   local found
-  for _ = 1, vim.v.count1 do
+  for _ = 1, count do
     if forward then
       if not inclusive and repeating then
         cursor[2] = cursor[2] + 1

--- a/scripts/ci-install-ubuntu-latest.sh
+++ b/scripts/ci-install-ubuntu-latest.sh
@@ -1,0 +1,9 @@
+wget -O - https://github.com/tree-sitter/tree-sitter/releases/download/${TREE_SITTER_CLI_TAG}/tree-sitter-linux-x64.gz | gunzip -c > tree-sitter
+sudo cp ./tree-sitter /usr/bin/tree-sitter
+sudo chmod uog+rwx /usr/bin/tree-sitter
+wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz
+tar -zxf nvim-linux64.tar.gz
+sudo ln -s $(pwd)/nvim-linux64/bin/nvim /usr/local/bin
+rm -rf $(pwd)/nvim-linux64/lib/nvim/parser
+mkdir -p ~/.local/share/nvim/site/pack/ci/opt
+ln -s $(pwd) ~/.local/share/nvim/site/pack/ci/opt

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,0 +1,223 @@
+vim.cmd [[
+packadd nvim-treesitter
+packadd nvim-treesitter-textobjects
+packadd plenary.nvim
+TSUpdate
+]]
+
+require("nvim-treesitter.configs").setup {
+  -- A list of parser names, or "all"
+  ensure_installed = "python",
+
+  -- Install parsers synchronously (only applied to `ensure_installed`)
+  sync_install = true,
+
+  -- Automatically install missing parsers when entering buffer
+  -- Recommendation: set to false if you don't have `tree-sitter` CLI installed locally
+  auto_install = true,
+
+  ---- If you need to change the installation directory of the parsers (see -> Advanced Setup)
+  -- Remember to run vim.opt.runtimepath:append("/some/path/to/store/parsers")!
+  -- parser_install_dir = "/some/path/to/store/parsers",
+
+  highlight = {
+    -- `false` will disable the whole extension
+    enable = true,
+
+    -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+    -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
+    -- Using this option may slow down your editor, and you may see some duplicate highlights.
+    -- Instead of true it can also be a list of languages
+    additional_vim_regex_highlighting = true,
+  },
+
+  textobjects = {
+    select = {
+      enable = true,
+
+      -- Automatically jump forward to textobj, similar to targets.vim
+      lookahead = true,
+
+      keymaps = {
+        -- You can use the capture groups defined in textobjects.scm
+        ["am"] = "@function.outer",
+        ["im"] = "@function.inner",
+        ["al"] = "@class.outer",
+        -- You can optionally set descriptions to the mappings (used in the desc parameter of
+        -- nvim_buf_set_keymap) which plugins like which-key display
+        ["il"] = { query = "@class.inner", desc = "Select inner part of a class region" },
+        ["ab"] = "@block.outer",
+        ["ib"] = "@block.inner",
+        ["ad"] = "@conditional.outer",
+        ["id"] = "@conditional.inner",
+        ["ao"] = "@loop.outer",
+        ["io"] = "@loop.inner",
+        ["aa"] = "@parameter.outer",
+        ["ia"] = "@parameter.inner",
+        ["af"] = "@call.outer",
+        ["if"] = "@call.inner",
+        ["ac"] = "@comment.outer",
+        ["ar"] = "@frame.outer",
+        ["ir"] = "@frame.inner",
+        ["at"] = "@attribute.outer",
+        ["it"] = "@attribute.inner",
+        ["ae"] = "@scopename.inner",
+        ["ie"] = "@scopename.inner",
+        ["as"] = "@statement.outer",
+        ["is"] = "@statement.outer",
+      },
+      -- You can choose the select mode (default is charwise 'v')
+      --
+      -- Can also be a function which gets passed a table with the keys
+      -- * query_string: eg '@function.inner'
+      -- * method: eg 'v' or 'o'
+      -- and should return the mode ('v', 'V', or '<c-v>') or a table
+      -- mapping query_strings to modes.
+      -- selection_modes = treesitter_selection_mode,
+      -- if you set this to `true` (default is `false`) then any textobject is
+      -- extended to include preceding or succeeding whitespace. succeeding
+      -- whitespace has priority in order to act similarly to eg the built-in
+      -- `ap`.
+      --
+      -- can also be a function which gets passed a table with the keys
+      -- * query_string: eg '@function.inner'
+      -- * selection_mode: eg 'v'
+      -- and should return true of false
+      include_surrounding_whitespace = false,
+    },
+    swap = {
+      enable = true,
+      swap_next = {
+        [")m"] = "@function.outer",
+        [")c"] = "@comment.outer",
+        [")a"] = "@parameter.inner",
+        [")b"] = "@block.outer",
+        [")C"] = "@class.outer",
+      },
+      swap_previous = {
+        ["(m"] = "@function.outer",
+        ["(c"] = "@comment.outer",
+        ["(a"] = "@parameter.inner",
+        ["(b"] = "@block.outer",
+        ["(C"] = "@class.outer",
+      },
+    },
+    move = {
+      enable = true,
+      set_jumps = true, -- whether to set jumps in the jumplist
+      goto_next_start = {
+        ["]m"] = "@function.outer",
+        ["]f"] = "@call.outer",
+        ["]d"] = "@conditional.outer",
+        ["]o"] = "@loop.outer",
+        ["]s"] = "@statement.outer",
+        ["]a"] = "@parameter.outer",
+        ["]c"] = "@comment.outer",
+        ["]b"] = "@block.outer",
+        ["]l"] = { query = "@class.outer", desc = "next class start" },
+        ["]r"] = "@frame.outer",
+        ["]t"] = "@attribute.outer",
+        ["]e"] = "@scopename.outer",
+        ["]]m"] = "@function.inner",
+        ["]]f"] = "@call.inner",
+        ["]]d"] = "@conditional.inner",
+        ["]]o"] = "@loop.inner",
+        ["]]a"] = "@parameter.inner",
+        ["]]b"] = "@block.inner",
+        ["]]l"] = { query = "@class.inner", desc = "next class start" },
+        ["]]r"] = "@frame.inner",
+        ["]]t"] = "@attribute.inner",
+        ["]]e"] = "@scopename.inner",
+      },
+      goto_next_end = {
+        ["]M"] = "@function.outer",
+        ["]F"] = "@call.outer",
+        ["]D"] = "@conditional.outer",
+        ["]O"] = "@loop.outer",
+        ["]S"] = "@statement.outer",
+        ["]A"] = "@parameter.outer",
+        ["]C"] = "@comment.outer",
+        ["]B"] = "@block.outer",
+        ["]L"] = "@class.outer",
+        ["]R"] = "@frame.outer",
+        ["]T"] = "@attribute.outer",
+        ["]E"] = "@scopename.outer",
+        ["]]M"] = "@function.inner",
+        ["]]F"] = "@call.inner",
+        ["]]D"] = "@conditional.inner",
+        ["]]O"] = "@loop.inner",
+        ["]]A"] = "@parameter.inner",
+        ["]]B"] = "@block.inner",
+        ["]]L"] = "@class.inner",
+        ["]]R"] = "@frame.inner",
+        ["]]T"] = "@attribute.inner",
+        ["]]E"] = "@scopename.inner",
+      },
+      goto_previous_start = {
+        ["[m"] = "@function.outer",
+        ["[f"] = "@call.outer",
+        ["[d"] = "@conditional.outer",
+        ["[o"] = "@loop.outer",
+        ["[s"] = "@statement.outer",
+        ["[a"] = "@parameter.outer",
+        ["[c"] = "@comment.outer",
+        ["[b"] = "@block.outer",
+        ["[l"] = "@class.outer",
+        ["[r"] = "@frame.outer",
+        ["[t"] = "@attribute.outer",
+        ["[e"] = "@scopename.outer",
+        ["[[m"] = "@function.inner",
+        ["[[f"] = "@call.inner",
+        ["[[d"] = "@conditional.inner",
+        ["[[o"] = "@loop.inner",
+        ["[[a"] = "@parameter.inner",
+        ["[[b"] = "@block.inner",
+        ["[[l"] = "@class.inner",
+        ["[[r"] = "@frame.inner",
+        ["[[t"] = "@attribute.inner",
+        ["[[e"] = "@scopename.inner",
+      },
+      goto_previous_end = {
+        ["[M"] = "@function.outer",
+        ["[F"] = "@call.outer",
+        ["[D"] = "@conditional.outer",
+        ["[O"] = "@loop.outer",
+        ["[S"] = "@statement.outer",
+        ["[A"] = "@parameter.outer",
+        ["[C"] = "@comment.outer",
+        ["[B"] = "@block.outer",
+        ["[L"] = "@class.outer",
+        ["[R"] = "@frame.outer",
+        ["[T"] = "@attribute.outer",
+        ["[E"] = "@scopename.outer",
+        ["[[M"] = "@function.inner",
+        ["[[F"] = "@call.inner",
+        ["[[D"] = "@conditional.inner",
+        ["[[O"] = "@loop.inner",
+        ["[[A"] = "@parameter.inner",
+        ["[[B"] = "@block.inner",
+        ["[[L"] = "@class.inner",
+        ["[[R"] = "@frame.inner",
+        ["[[T"] = "@attribute.inner",
+        ["[[E"] = "@scopename.inner",
+      },
+    },
+  },
+}
+
+local ts_repeat_move = require "nvim-treesitter.textobjects.repeatable_move"
+
+-- Repeat movement with ; and ,
+-- ensure ; goes forward and , goes backward regardless of the last direction
+-- vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next)
+-- vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous)
+
+-- vim way: ; goes to the direction you were moving.
+vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)
+vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_opposite)
+
+-- Optionally, make builtin f, F, t, T also repeatable with ; and ,
+vim.keymap.set({ "n", "x", "o" }, "f", ts_repeat_move.builtin_f)
+vim.keymap.set({ "n", "x", "o" }, "F", ts_repeat_move.builtin_F)
+vim.keymap.set({ "n", "x", "o" }, "t", ts_repeat_move.builtin_t)
+vim.keymap.set({ "n", "x", "o" }, "T", ts_repeat_move.builtin_T)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+HERE="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+cd $HERE/..
+
+run() {
+    nvim --headless --noplugin -u scripts/minimal_init.lua \
+        -c "PlenaryBustedDirectory $1 { minimal_init = './scripts/minimal_init.lua' }"
+}
+
+if [[ $2 = '--summary' ]]; then
+    ## really simple results summary by filtering plenary busted output
+    run tests/$1  2> /dev/null | grep -E '^\S*(Testing|Success|Failed|Errors)\s*:'
+else
+    run tests/$1
+fi

--- a/tests/repeatable_move/common.lua
+++ b/tests/repeatable_move/common.lua
@@ -1,0 +1,98 @@
+local M = {}
+
+local assert = require "luassert"
+local Path = require "plenary.path"
+
+-- Test in all possible col position
+-- f, F, t, T
+-- ; , repeat
+-- count repeat
+function M.run_builtin_find_test(file, spec)
+  assert.are.same(1, vim.fn.filereadable(file), string.format('File "%s" not readable', file))
+
+  -- load reference file
+  vim.cmd(string.format("edit %s", file))
+
+  vim.api.nvim_win_set_cursor(0, { spec.row, 0 })
+  local line = vim.api.nvim_get_current_line()
+  local num_cols = #line
+
+  for col = 0, num_cols - 1 do
+    for _, cmd in pairs { "f", "F", "t", "T" } do
+      for _, repeat_cmd in pairs { ";", "," } do
+        -- Get ground truth using vim's built-in search and repeat
+        vim.api.nvim_win_set_cursor(0, { spec.row, col })
+        local gt_cols = {}
+        vim.cmd([[normal! ]] .. cmd .. spec.char)
+        gt_cols[#gt_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal! ]] .. repeat_cmd)
+        gt_cols[#gt_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal! 2]] .. repeat_cmd)
+        gt_cols[#gt_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal! l]] .. repeat_cmd)
+        gt_cols[#gt_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal! h]] .. repeat_cmd)
+        gt_cols[#gt_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal! 2]] .. cmd .. spec.char)
+        gt_cols[#gt_cols + 1] = vim.fn.col "."
+
+        -- test using tstextobj repeatable_move.lua
+        vim.api.nvim_win_set_cursor(0, { spec.row, col })
+        local ts_cols = {}
+        vim.cmd([[normal ]] .. cmd .. spec.char)
+        assert.are.same(spec.row, vim.fn.line ".", "Command shouldn't move cursor over rows")
+        ts_cols[#ts_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal ]] .. repeat_cmd)
+        assert.are.same(spec.row, vim.fn.line ".", "Command shouldn't move cursor over rows")
+        ts_cols[#ts_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal 2]] .. repeat_cmd)
+        assert.are.same(spec.row, vim.fn.line ".", "Command shouldn't move cursor over rows")
+        ts_cols[#ts_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal l]] .. repeat_cmd)
+        assert.are.same(spec.row, vim.fn.line ".", "Command shouldn't move cursor over rows")
+        ts_cols[#ts_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal h]] .. repeat_cmd)
+        assert.are.same(spec.row, vim.fn.line ".", "Command shouldn't move cursor over rows")
+        ts_cols[#ts_cols + 1] = vim.fn.col "."
+        vim.cmd([[normal 2]] .. cmd .. spec.char)
+        assert.are.same(spec.row, vim.fn.line ".", "Command shouldn't move cursor over rows")
+        ts_cols[#ts_cols + 1] = vim.fn.col "."
+
+        assert.are.same(
+          gt_cols,
+          ts_cols,
+          string.format("Command %s works differently than vim's built-in find, col: %d", cmd, col)
+        )
+      end
+    end
+  end
+  -- clear any changes to avoid 'No write since last change (add ! to override)'
+  vim.cmd "edit!"
+end
+
+local Runner = {}
+Runner.__index = Runner
+
+-- Helper to avoid boilerplate when defining tests
+-- @param it  the "it" function that busted defines globally in spec files
+-- @param base_dir  all other paths will be resolved relative to this directory
+-- @param buf_opts  buffer options passed to set_buf_indent_opts
+function Runner:new(it, base_dir, buf_opts)
+  local runner = {}
+  runner.it = it
+  runner.base_dir = Path:new(base_dir)
+  runner.buf_opts = buf_opts
+  return setmetatable(runner, self)
+end
+
+function Runner:builtin_find(file, spec, title)
+  title = title and title or tostring(spec.row)
+  self.it(string.format("%s[%s]", file, title), function()
+    local path = self.base_dir / file
+    M.run_builtin_find_test(path.filename, spec)
+  end)
+end
+
+M.Runner = Runner
+
+return M

--- a/tests/repeatable_move/python/aligned_indent.py
+++ b/tests/repeatable_move/python/aligned_indent.py
@@ -1,0 +1,14 @@
+def aligned_indent(arg1nsdkjdsnsdnfsadnnnnfsn,
+                   arg2):
+    pass
+
+aligned_indent(1,
+               2)
+
+
+aligned_indent(1,
+               2
+               )
+
+foodsadsa(sdada,
+          2

--- a/tests/repeatable_move/python_spec.lua
+++ b/tests/repeatable_move/python_spec.lua
@@ -1,0 +1,14 @@
+local Runner = require("tests.repeatable_move.common").Runner
+
+local run = Runner:new(it, "tests/repeatable_move/python", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 0,
+  expandtab = true,
+})
+
+describe("builtin find Python:", function()
+  describe("repeat:", function()
+    run:builtin_find("aligned_indent.py", { row = 1, char = "n" })
+  end)
+end)

--- a/tests/select/common.lua
+++ b/tests/select/common.lua
@@ -1,0 +1,65 @@
+local M = {}
+
+local assert = require "luassert"
+local Path = require "plenary.path"
+
+-- Test in all possible col position
+-- f, F, t, T
+-- ; , repeat
+-- count repeat
+function M.run_equal_cmds_test(file, spec)
+  assert.are.same(1, vim.fn.filereadable(file), string.format('File "%s" not readable', file))
+
+  -- load reference file
+  vim.cmd(string.format("edit %s", file))
+
+  local first_cmd_lines = nil
+  for _, cmd in pairs(spec.cmds) do
+    -- set cursor pos
+    vim.api.nvim_win_set_cursor(0, { spec.row, spec.col })
+    -- run command
+    vim.cmd([[normal ]] .. vim.api.nvim_replace_termcodes(cmd, true, true, true))
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
+    if first_cmd_lines == nil then
+      first_cmd_lines = lines
+    end
+
+    -- clear any changes (avoid no write since last change)
+    -- call before assert
+    vim.cmd "edit!"
+
+    assert.are.same(
+      first_cmd_lines,
+      lines,
+      string.format("Commands %s and %s produces different results", spec.cmds[1], cmd)
+    )
+  end
+end
+
+local Runner = {}
+Runner.__index = Runner
+
+-- Helper to avoid boilerplate when defining tests
+-- @param it  the "it" function that busted defines globally in spec files
+-- @param base_dir  all other paths will be resolved relative to this directory
+-- @param buf_opts  buffer options passed to set_buf_indent_opts
+function Runner:new(it, base_dir, buf_opts)
+  local runner = {}
+  runner.it = it
+  runner.base_dir = Path:new(base_dir)
+  runner.buf_opts = buf_opts
+  return setmetatable(runner, self)
+end
+
+function Runner:equal_cmds(file, spec, title)
+  title = title and title or string.format("%s,%s", spec.row, spec.col)
+  self.it(string.format("%s[%s]", file, title), function()
+    local path = self.base_dir / file
+    M.run_equal_cmds_test(path.filename, spec)
+  end)
+end
+
+M.Runner = Runner
+
+return M

--- a/tests/select/python/aligned_indent.py
+++ b/tests/select/python/aligned_indent.py
@@ -1,0 +1,14 @@
+def aligned_indent(arg1nsdkjdsnsdnfsadnnnnfsn,
+                   arg2):
+    pass
+
+aligned_indent(1,
+               2)
+
+
+aligned_indent(1,
+               2
+               )
+
+foodsadsa(sdada,
+          2

--- a/tests/select/python_spec.lua
+++ b/tests/select/python_spec.lua
@@ -1,0 +1,22 @@
+local Runner = require("tests.select.common").Runner
+
+local run = Runner:new(it, "tests/select/python", {
+  tabstop = 4,
+  shiftwidth = 4,
+  softtabstop = 0,
+  expandtab = true,
+})
+
+describe("command equality Python:", function()
+  run:equal_cmds("aligned_indent.py", { row = 1, col = 0, cmds = { "daa", "vaad", "caa" } })
+  run:equal_cmds("aligned_indent.py", { row = 1, col = 10, cmds = { "dia", "viad", "cia" } })
+  run:equal_cmds("aligned_indent.py", {
+    row = 1,
+    col = 0,
+    cmds = {
+      "diahx",
+      "viadhx",
+      "cia<bs>",
+    },
+  })
+end)


### PR DESCRIPTION
Added tests for:
1. repeatable move builtins (by comparing actual movement from vim's builtins)
2. select consistency (`viad`, `cia`, `dia` should be the same)

One test fails because currently there is a glitch.
Using https://github.com/nvim-treesitter/nvim-treesitter/pull/4228 will make all tests pass.

By doing this, I noticed that the builtin find movements we implemented have a very minor difference.  
For some reason, if you use `t` and repeat with `;`, then the default count is 2, so `;` and `2;` should work the same way.