### PR TITLE
Add @comment.inner to elixir documentation elements

### DIFF
--- a/queries/elixir/textobjects.scm
+++ b/queries/elixir/textobjects.scm
@@ -70,12 +70,21 @@
 ; Documentation Objects
 (unary_operator 
   operator: "@"
-  operand: (call target: ((identifier) @_identifier (#any-of? @_identifier
-    "moduledoc" 
-    "typedoc" 
-    "shortdoc" 
-    "doc"
-  )))
+  operand: (
+    call target: ((identifier) @_identifier (#any-of? @_identifier
+      "moduledoc" 
+      "typedoc" 
+      "shortdoc" 
+      "doc"
+    ))
+  (arguments [
+    ; attributes style documentation
+    ; @doc deprecated: "...."
+    (keywords) @comment.inner
+    ; heredoc style documentation
+    ; @moduledoc """"""
+    (string (quoted_content) @comment.inner)
+  ]))
 ) @comment.outer
 
 ; Regex Objects


### PR DESCRIPTION
Added a capture to the inner contents of an elixir documentation tag. These tend to come in two forms: the string form and the options form

String form

```elixir
@moduledoc """
Hey look! Some documentation.
"""
```

Performing a `@comment.inner` change on the documentation would leave you in the following state.

```elixir
@moduledoc """|"""
```

I tried the best I could to have the state be the following but I don't know if its possible easily, how I have it is the next best thing.

```elixir
@moduledoc """
|
"""
```

Options form of documentation elements.

```elixir
@doc deprecated: "Use .... instead"
```

Same `@comment.inner` edit would get you to this state.

```elixir
@doc |
```