### PR TITLE
 fix(elixir): handle last block bug for @class.inner 

### DIFF
--- a/queries/elixir/textobjects.scm
+++ b/queries/elixir/textobjects.scm
@@ -5,6 +5,7 @@
 ] (#make-range! "block.inner" @_do @_end)) @block.outer
 
 ; Class Objects (Modules, Protocols)
+; multiple children
 (call
   target: ((identifier) @_identifier (#any-of? @_identifier 
     "defmodule" 
@@ -12,11 +13,19 @@
     "defimpl"
   ))
   (arguments (alias))
-  [
-    (do_block "do" . (_) @_do (_) @_end . "end")
-    (do_block "do" . ((_) @_do) @_end . "end")
-  ]
+  (do_block "do" . (_) @_do (_) @_end . "end")
   (#make-range! "class.inner" @_do @_end)
+) @class.outer
+
+; single child match
+(call
+  target: ((identifier) @_identifier (#any-of? @_identifier 
+    "defmodule" 
+    "defprotocol" 
+    "defimpl"
+  ))
+  (arguments (alias))
+  (do_block "do" . (_) @class.inner . "end")
 ) @class.outer
 
 ; Function, Parameter, and Call Objects


### PR DESCRIPTION
With the previous matches if you triggered a `@class.inner` change and you happened to be in the last block of a module it would only change that block instead of deleting all the blocks of the module.

For example with a file such as this where `|` is the cursor:

```elixir
defmodule Test do
  def hello() do
    IO.puts("hi")
  end

  def oi() do
    |IO.puts("oi")
  end
end
```

After the edit you'd have:

```elixir
defmodule Test do
  def hello() do
    IO.puts("hi")
  end

  |
end
```


The previous approach was using a single query and then trying to build
a range over all children of a block, or in the case of a single child
using it as the start and end. I could not for the life of me figure out
a way to write this to work. As soon as I broke it out to two queries:
one with a make range and one that just captures the one child things
worked.