### PR TITLE
Fix: Operator-pending missing last character in builtin finds

### DIFF
--- a/lua/nvim-treesitter/textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter/textobjects/repeatable_move.lua
@@ -190,6 +190,13 @@ local function builtin_find(opts)
     repeating = true -- after the first iteration, search from the next character if not inclusive.
   end
 
+  -- Enter visual mode if we are in operator-pending mode
+  -- If we don't do this, it will miss the last character.
+  local mode = vim.api.nvim_get_mode()
+  if mode.mode == "no" then
+    vim.cmd "normal! v"
+  end
+
   -- move to the found position
   vim.api.nvim_win_set_cursor(winid, { cursor[1], cursor[2] })
   return char

--- a/tests/select/common.lua
+++ b/tests/select/common.lua
@@ -3,10 +3,6 @@ local M = {}
 local assert = require "luassert"
 local Path = require "plenary.path"
 
--- Test in all possible col position
--- f, F, t, T
--- ; , repeat
--- count repeat
 function M.run_equal_cmds_test(file, spec)
   assert.are.same(1, vim.fn.filereadable(file), string.format('File "%s" not readable', file))
 

--- a/tests/select/python_spec.lua
+++ b/tests/select/python_spec.lua
@@ -19,4 +19,8 @@ describe("command equality Python:", function()
       "cia<bs>",
     },
   })
+  -- select using built-in finds (f, F, t, T)
+  run:equal_cmds("aligned_indent.py", { row = 1, col = 0, cmds = { "dfi", "vfid", "cfi" } })
+  -- select using move
+  run:equal_cmds("aligned_indent.py", { row = 1, col = 0, cmds = { "d]a", "v]ad", "c]a" } })
 end)


### PR DESCRIPTION
Fixes #381 and adds tests to check the equality of `vfid`, `dfi` and `cfi`  
plus `v]a`, `d]a` and `c]a` (`@parameter.outer`)

Note that this is not limited to built-in finds. Currently the test fails because the node movements have the same error.  

https://github.com/nvim-treesitter/nvim-treesitter/pull/4283 will make the failing test pass.