### PR TITLE
Feat: prefer select within outer range

### DIFF
--- a/.github/workflows/consistency_tests.yml
+++ b/.github/workflows/consistency_tests.yml
@@ -28,7 +28,7 @@ jobs:
           wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim.appimage
           chmod u+x nvim.appimage && sudo mv nvim.appimage /usr/local/bin/nvim
 
-          git clone -b v0.1.0 --depth 1 https://github.com/kiyoon/nvim-treesitter-textobjects-tests
+          git clone -b v0.1.1 --depth 1 https://github.com/kiyoon/nvim-treesitter-textobjects-tests
 
           mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter-textobject/opt
           ln -s $(pwd) ~/.local/share/nvim/site/pack/nvim-treesitter-textobject/opt

--- a/lua/nvim-treesitter-textobjects.lua
+++ b/lua/nvim-treesitter-textobjects.lua
@@ -1,11 +1,10 @@
-local queries = require "nvim-treesitter.query"
 local configs = require "nvim-treesitter.configs"
 local utils = require "nvim-treesitter.utils"
 
 local M = {}
 
 M.has_textobjects = function(lang)
-  return queries.has_query_files(lang, "textobjects")
+  return vim.treesitter.query.get_query_files(lang, "textobjects") ~= nil
 end
 
 local function has_some_textobject_mapping(lang)

--- a/lua/nvim-treesitter/textobjects/attach.lua
+++ b/lua/nvim-treesitter/textobjects/attach.lua
@@ -1,6 +1,4 @@
 local configs = require "nvim-treesitter.configs"
-local parsers = require "nvim-treesitter.parsers"
-local queries = require "nvim-treesitter.query"
 local M = {}
 
 local function make_dot_repeatable(fn)
@@ -25,11 +23,7 @@ function M.make_attach(functions, submodule, keymap_modes, opts)
   local keymaps_per_buf = M.keymaps_per_submodule[submodule]
 
   return function(bufnr, lang)
-    lang = lang or parsers.get_buf_lang(bufnr)
-    if not queries.get_query(lang, "textobjects") then
-      return
-    end
-
+    -- lang = lang or parsers.get_buf_lang(bufnr)
     local config = configs.get_module("textobjects." .. submodule)
 
     for _, function_call in pairs(functions) do

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -108,3 +108,10 @@
 
 ;; number
 (number) @number.inner
+
+(variable_declarator
+ name: (_) @assignment.lhs
+ value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+
+(variable_declarator
+ name: (_) @assignment.inner)

--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -93,6 +93,13 @@
 ; number
 (number) @number.inner
 
+(assignment_statement
+ (variable_list) @assignment.lhs
+ (expression_list) @assignment.inner @assignment.rhs) @assignment.outer
+
+(assignment_statement
+ (variable_list) @assignment.inner)
+
 ; scopename
 
 ; statement

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -164,4 +164,11 @@
   (float)
 ] @number.inner
 
+(assignment
+ left: (_) @assignment.lhs
+ right: (_) @assignment.inner @assignment.rhs) @assignment.outer
+
+(assignment
+ left: (_) @assignment.inner)
+
 ; TODO: exclude comments using the future negate syntax from tree-sitter

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -171,3 +171,17 @@
   (integer_literal)
   (float_literal)
 ] @number.inner
+
+(let_declaration
+ pattern: (_) @assignment.lhs
+ value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+
+(let_declaration
+ pattern: (_) @assignment.inner)
+
+(assignment_expression
+ left: (_) @assignment.lhs
+ right: (_) @assignment.inner @assignment.rhs) @assignment.outer
+
+(assignment_expression
+ left: (_) @assignment.inner)

--- a/queries/vim/textobjects.scm
+++ b/queries/vim/textobjects.scm
@@ -27,3 +27,10 @@
   (integer_literal)
   (float_literal)
 ] @number.inner
+
+(let_statement
+  (_) @assignment.lhs
+  (_) @assignment.rhs @assignment.inner) @assignment.outer
+
+(let_statement
+  (_) @assignment.inner)

--- a/scripts/check-queries.lua
+++ b/scripts/check-queries.lua
@@ -22,7 +22,6 @@ end
 
 local function do_check()
   local parsers = require("nvim-treesitter.parsers").available_parsers()
-  local queries = require "nvim-treesitter.query"
   local query_types = { "textobjects" }
 
   local captures = extract_captures()
@@ -30,7 +29,7 @@ local function do_check()
   for _, lang in pairs(parsers) do
     for _, query_type in pairs(query_types) do
       print("Checking " .. lang .. " " .. query_type)
-      local query = queries.get_query(lang, query_type)
+      local query = vim.treesitter.query.get_query(lang, query_type)
 
       if query then
         for _, capture in ipairs(query.captures) do


### PR DESCRIPTION
This PR includes rewriting using `vim.treesitter` over `nvim-treesitter` partially.

The problem with the previous method is that there is no association with @*.inner and @*.outer textobjects. So even if you're within the range of an outer area, the inner will select something wrong.

The problem occurs when the cursor is in between the outer range and inner range. In that case, the `@function.inner` will choose the larger context like the main function.

This patch provides solution for #335, #328, #125, and #15.

Additionally, I wrote `@assignment.outer`, `@assignment.inner`, `@assignment.lhs`, `@assignment.rhs` queries for python, lua, rust, vim, and js (ecma). This way you can select the left hand side (lhs) from the right hand side cursor (as the cursor is within the range of outer).

Quick demos:

1. You can go outer to inner seamlessly.


[Screencast from 10-02-23 16:48:30.webm](https://user-images.githubusercontent.com/12980409/218148965-bda00ffb-4352-4d30-9c72-70474494f9a4.webm)

3. It will select more relevant part.


[Screencast from 10-02-23 16:53:25.webm](https://user-images.githubusercontent.com/12980409/218150106-9503b9d7-f48e-46e9-a4f3-3a6864b9e5e6.webm)


Notice that this will break the Consistency Tests, and I will update the snapshot once it gets merged.