### PR TITLE
docs: add documentation hint for `query_group`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ require'nvim-treesitter.configs'.setup {
         -- You can optionally set descriptions to the mappings (used in the desc parameter of
         -- nvim_buf_set_keymap) which plugins like which-key display
         ["ic"] = { query = "@class.inner", desc = "Select inner part of a class region" },
+        -- You can also use captures from other query groups like `locals.scm`
+        ["as"] = { query = "@scope", query_group = "locals", desc = "Select language scope" },
       },
       -- You can choose the select mode (default is charwise 'v')
       --


### PR DESCRIPTION
Add reminder to README.md on how to use alternative query groups, because I forgot and didn't know where to look up.