### PR TITLE
feat: add return textobject for C/CPP/Lua/Python/Rust/Vim

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ Each capture group can be declared as `inner` or `outer`.
 @comment.outer
 @assignment.inner
 @assignment.outer
+@return.inner
+@return.outer
 
 # For LaTeX frames
 @frame.inner

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -45,6 +45,9 @@
   arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
   (#make-range! "call.inner" @_start @_end)))
 
+(return_statement
+  (_)? @return.inner) @return.outer
+
 ; Statements
 
 ;(expression_statement ;; this is what we actually want to capture in most cases (";" is missing) probably

--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -44,6 +44,11 @@
 
 (function_definition body: (_) @function.inner)
 
+; return
+
+(return_statement
+  (_)? @return.inner) @return.outer
+
 ; loop
 
 [

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -36,6 +36,9 @@
   arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
   (#make-range! "call.inner" @_start @_end)))
 
+(return_statement
+  (_)? @return.inner) @return.outer
+
 ;; Parameters
 
 ((parameters

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -75,6 +75,10 @@
   arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"
   (#make-range! "call.inner" @_start @_end)))
 
+;; returns
+(return_expression
+  (_)? @return.inner) @return.outer
+
 ;; statements
 (block (_) @statement.outer)
 

--- a/queries/vim/textobjects.scm
+++ b/queries/vim/textobjects.scm
@@ -16,6 +16,9 @@
 
 (call_expression) @call.outer
 
+(return_statement
+  (_)? @return.inner) @return.outer
+
 (_ (body) @block.inner) @block.outer
 (body (_) @statement.outer)
 


### PR DESCRIPTION
But sadly, Rust's return textobject works only for explicit return statements, and doesn't work for most functions because [most functions return the last expression implicitly](https://doc.rust-lang.org/stable/book/ch03-03-how-functions-work.html#functions-with-return-values) (without explicit `return` keyword).