### PR TITLE
v: Add V textobjects

### DIFF
--- a/queries/v/textobjects.scm
+++ b/queries/v/textobjects.scm
@@ -1,0 +1,61 @@
+;; assignment
+[(short_var_declaration
+    left: (_) @assignment.lhs
+    right: (_)* @assignment.rhs @assignment.inner)
+  (assignment_statement
+    left: (_) @assignment.lhs
+    right: (_)* @assignment.rhs @assignment.inner)] @assignment.outer
+
+;; block
+(_ (block) @block.inner) @block.outer
+
+;; call
+(call_expression) @call.outer
+(call_expression
+  arguments: (argument_list . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
+
+;; class: structs
+(struct_declaration
+  (struct_field_declaration_list . "{" . (_) @_start @_end (_)? @_end . "}"
+  (#make-range! "class.inner" @_start @_end)))
+
+(struct_declaration) @class.outer
+
+;; comment
+((comment) @comment.inner @comment.outer
+  (#offset! @comment.inner 0 3 0))
+
+;; conditional
+(if_expression
+  consequence: (block . "{" . (_) @_start @_end (_)? @_end . "}"
+    (#make-range! "conditional.inner" @_start @_end))?) @conditional.outer
+
+;; function
+(function_declaration
+  body: (block . "{" . (_) @_start @_end (_)? @_end . "}"
+ (#make-range! "function.inner" @_start @_end)))
+
+(function_declaration) @function.outer
+
+;; loop
+(for_statement
+  body: (block . "{" . (_) @_start @_end (_)? @_end . "}"
+    (#make-range! "loop.inner" @_start @_end))?) @loop.outer
+
+;; parameter
+(parameter_list
+  "," @_start .
+  (parameter_declaration) @parameter.inner
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+
+(parameter_list
+  . (parameter_declaration) @parameter.inner
+  . ","? " "? @_end
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
+;; return
+(return_statement (_)* @return.inner) @return.outer
+
+;; statements
+(block (_) @statement.outer)

--- a/queries/v/textobjects.scm
+++ b/queries/v/textobjects.scm
@@ -1,10 +1,20 @@
 ;; assignment
 [(short_var_declaration
     left: (_) @assignment.lhs
-    right: (_)* @assignment.rhs @assignment.inner)
+    right: (_)* @assignment.rhs)
   (assignment_statement
     left: (_) @assignment.lhs
-    right: (_)* @assignment.rhs @assignment.inner)] @assignment.outer
+    right: (_)* @assignment.rhs)]
+
+[(short_var_declaration
+    left: (_) @assignment.inner)
+  (assignment_statement
+    left: (_) @assignment.inner)]
+
+[(short_var_declaration
+    right: (_) @assignment.inner)
+  (assignment_statement
+    right: (_) @assignment.inner)]
 
 ;; block
 (_ (block) @block.inner) @block.outer

--- a/queries/v/textobjects.scm
+++ b/queries/v/textobjects.scm
@@ -33,8 +33,14 @@
 (struct_declaration) @class.outer
 
 ;; comment
+; leave space after comment marker if there is one
 ((comment) @comment.inner @comment.outer
-  (#offset! @comment.inner 0 3 0))
+           (#offset! @comment.inner 0 3 0)
+           (#lua-match? @comment.outer "// .*"))
+
+; else remove everything accept comment marker
+((comment) @comment.inner @comment.outer
+  (#offset! @comment.inner 0 2 0))
 
 ;; conditional
 (if_expression

--- a/queries/v/textobjects.scm
+++ b/queries/v/textobjects.scm
@@ -59,6 +59,11 @@
   body: (block . "{" . (_) @_start @_end (_)? @_end . "}"
     (#make-range! "loop.inner" @_start @_end))?) @loop.outer
 
+[
+  (int_literal)
+  (float_literal)
+] @number.inner
+
 ;; parameter
 (parameter_list
   "," @_start .

--- a/queries/v/textobjects.scm
+++ b/queries/v/textobjects.scm
@@ -17,7 +17,8 @@
     right: (_) @assignment.inner)]
 
 ;; block
-(_ (block) @block.inner) @block.outer
+(_ (block . "{" . (_) @_start @_end (_)? @_end . "}")
+   (#make-range! "block.inner" @_start @_end)) @block.outer
 
 ;; call
 (call_expression) @call.outer


### PR DESCRIPTION
The following textobjects are added:

- [x] @assignment.inner (`mut x = |[]string{}|`)
- [x] @assignment.lhs (`|mut x| = []string{}`)
- [x] @assignment.outer (`|mut x = []string{}|`)
- [x] @assignment.rhs (`mut x = |[]string{}|`)
- [ ] @attribute.inner
- [ ] @attribute.outer
- [x] @block.inner
- [x] @block.outer
- [x] @call.inner
- [x] @call.outer
- [x] @class.inner
- [x] @class.outer
- [x] @comment.inner (`// |example|`)
- [x] @comment.outer (`|// example|`)
- [x] @conditional.inner (`if true { |pass| }`)
- [x] @conditional.outer (`|if true { pass }|`)
- [ ] @frame.inner
- [ ] @frame.outer
- [x] @number.inner
- [x] @function.inner
- [x] @function.outer
- [x] @loop.inner (`for num in numbers { |pass| }`)
- [x] @loop.outer (`|for num in numbers { pass }|`)
- [x] @parameter.inner
- [x] @parameter.outer
- [ ] @regex.inner
- [ ] @regex.outer
- [x] @return.inner
- [x] @return.outer
- [ ] @scopename.inner
- [x] @statement.outer

I've based most queries on Go's from current master.