### PR TITLE
python: add `@comment.inner`

### DIFF
--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -26,7 +26,8 @@
   condition: (_) @conditional.inner)
 
 (_ (block) @block.inner) @block.outer
-(comment) @comment.outer
+((comment) @comment.inner @comment.outer
+  (#offset! @comment.inner 0 2 0))
 
 (block (_) @statement.outer)
 (module (_) @statement.outer)

--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -26,8 +26,16 @@
   condition: (_) @conditional.inner)
 
 (_ (block) @block.inner) @block.outer
+
+; leave space after comment marker if there is one
 ((comment) @comment.inner @comment.outer
-  (#offset! @comment.inner 0 2 0))
+           (#offset! @comment.inner 0 2 0)
+           (#lua-match? @comment.outer "# .*"))
+
+; else remove everything accept comment marker
+((comment) @comment.inner @comment.outer
+  (#offset! @comment.inner 0 1 0))
+
 
 (block (_) @statement.outer)
 (module (_) @statement.outer)


### PR DESCRIPTION
```python
# test
--- cic ---
# |
```

and
```python
#test
--- cic ---
#|
```

where `|` denotes the cursor.

I added the first as 'special case', because I think that is (and should be) how most programmers use comments: *always* having a space after the comment marker. Adding this as a special case skips having to add the space every time after something like `cic`.