### PR TITLE
fish: add textobjects

### DIFF
--- a/queries/fish/textobjects.scm
+++ b/queries/fish/textobjects.scm
@@ -11,13 +11,17 @@
   argument: (_)* @assignment.inner
   (#eq? @_name "set"))
 
-; ;; block
-; ([
-;  (case_clause)
-;  (if_statement)
-;  (switch_statement)
-;  (else_clause)
-; ] (_) @block.inner) @block.outer
+;; block
+([
+ (case_clause)
+ (if_statement)
+ (switch_statement)
+ (else_clause)
+ (for_statement)
+ (while_statement)
+]) @block.outer
+
+
 
 ;; call
 ; call.inner doesn't work because it can't select *all* arguments

--- a/queries/fish/textobjects.scm
+++ b/queries/fish/textobjects.scm
@@ -1,5 +1,50 @@
-(function_definition) @function.outer
+;; assignment
+(command
+  name: (word) @_command
+  argument: (word) @_varname @assignment.lhs @assignment.inner
+  argument: (_)* @assignment.rhs
+  (#not-lua-match? @_varname "[-].*")
+  (#eq? @_command "set")) @assignment.outer
 
+(command
+  name: (word) @_name
+  argument: (_)* @assignment.inner
+  (#eq? @_name "set"))
+
+; ;; block
+; ([
+;  (case_clause)
+;  (if_statement)
+;  (switch_statement)
+;  (else_clause)
+; ] (_) @block.inner) @block.outer
+
+;; call
+; call.inner doesn't work because it can't select *all* arguments
+(command) @call.outer
+
+;; comment
+; leave space after comment marker if there is one
+((comment) @comment.inner @comment.outer
+           (#offset! @comment.inner 0 2 0)
+           (#lua-match? @comment.outer "# .*"))
+
+; else remove everything accept comment marker
+((comment) @comment.inner @comment.outer
+  (#offset! @comment.inner 0 1 0))
+
+;; conditional
+(if_statement
+  (command) @conditional.inner) @conditional.outer
+
+(switch_statement
+  (_) @conditional.inner) @conditional.outer
+
+;; function
+((function_definition) @function.inner @function.outer
+  (#offset! @function.inner 1 0 -1 1))
+
+;; loop
 (for_statement
   (_) @loop.inner) @loop.outer
 
@@ -7,10 +52,15 @@
   condition: (command)
   (command) @loop.inner) @loop.outer
 
-(if_statement
-  (command) @conditional.inner) @conditional.outer
+;; number
+[(integer) (float)] @number.inner
 
-(switch_statement 
-  (_) @conditional.inner) @conditional.outer
+;; parameter
+(command
+  argument: (_) @parameter.outer)
 
-(comment) @comment.outer
+;; return
+(return (_) @return.inner) @return.outer
+
+;; statement
+(command) @statement.outer


### PR DESCRIPTION
Fish's treesitter has a weird way of not using unique field values.

```fish
set -q x "hello"
```
Gives:
```
command [0, 0] - [0, 16]
  name: word [0, 0] - [0, 3]
  argument: word [0, 4] - [0, 6]
  argument: word [0, 7] - [0, 8]
  argument: double_quote_string [0, 9] - [0, 16]
```

I can't seem to get *all* arguments, to use e.g. for `@call.inner`. Let me know if this is possible, then I'll add the functionality of those