### PR TITLE
fix: TSTextobjSelect command

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -141,6 +141,10 @@ function M.detect_selection_mode(query_string, keymap_mode)
   visual_mode = visual_mode:sub(#visual_mode)
   selection_mode = visual_mode == "o" and selection_mode or visual_mode
 
+  if selection_mode == "n" then
+    selection_mode = "v"
+  end
+
   return selection_mode
 end
 


### PR DESCRIPTION
Fixes #418 

The `selection_mode` variable should not be `"n"`, but it's inferring the mode from the current mode which is normal mode. 