### PR TITLE
fix: detect_selection_mode()

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -1,9 +1,9 @@
 local api = vim.api
-local configs = require("nvim-treesitter.configs")
-local parsers = require("nvim-treesitter.parsers")
+local configs = require "nvim-treesitter.configs"
+local parsers = require "nvim-treesitter.parsers"
 
-local shared = require("nvim-treesitter.textobjects.shared")
-local ts_utils = require("nvim-treesitter.ts_utils")
+local shared = require "nvim-treesitter.textobjects.shared"
+local ts_utils = require "nvim-treesitter.ts_utils"
 
 local M = {}
 
@@ -127,7 +127,7 @@ function M.detect_selection_mode(query_string, keymap_mode)
   }
   local method = keymap_to_method[keymap_mode]
 
-  local config = configs.get_module("textobjects.select")
+  local config = configs.get_module "textobjects.select"
   local selection_modes = val_or_return(config.selection_modes, { query_string = query_string, method = method })
   local selection_mode
   if type(selection_modes) == "table" then
@@ -161,7 +161,7 @@ M.keymaps_per_buf = {}
 
 function M.attach(bufnr, lang)
   bufnr = bufnr or api.nvim_get_current_buf()
-  local config = configs.get_module("textobjects.select")
+  local config = configs.get_module "textobjects.select"
   lang = lang or parsers.get_buf_lang(bufnr)
 
   for mapping, query in pairs(config.keymaps) do
@@ -192,7 +192,7 @@ function M.attach(bufnr, lang)
     end
 
     if query_string then
-      for _, keymap_mode in ipairs({ "o", "x" }) do
+      for _, keymap_mode in ipairs { "o", "x" } do
         local cmd = function()
           M.select_textobject(query_string, query_group, keymap_mode)
         end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -137,9 +137,16 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
   -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
   -- last set `selection_mode`
+  -- Also, we need to handle cases that 
+  -- the value returned from vim.fn.mode()
+  -- ends with {'nov', 'noV', 'v', 'V'}
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
-  selection_mode = visual_mode ~= "o" and selection_mode or visual_mode
+
+  local valid_chars = {"o", "v", "V"}
+  if not vim.tbl_contains(valid_chars, visual_mode) then
+    selection_mode = visual_mode
+  end
 
   if selection_mode == "n" then
     selection_mode = "v"

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -100,14 +100,14 @@ function M.select_textobject(query_string, query_group, keymap_mode)
   local lookbehind = configs.get_module("textobjects.select").lookbehind
   local surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
   local bufnr, textobject =
-    shared.textobject_at_point(query_string, query_group, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
+      shared.textobject_at_point(query_string, query_group, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
   if textobject then
     local selection_mode = M.detect_selection_mode(query_string, keymap_mode)
     if
-      val_or_return(surrounding_whitespace, {
-        query_string = query_string,
-        selection_mode = selection_mode,
-      })
+        val_or_return(surrounding_whitespace, {
+          query_string = query_string,
+          selection_mode = selection_mode,
+        })
     then
       textobject = include_surrounding_whitespace(bufnr, textobject, selection_mode)
     end
@@ -137,13 +137,13 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
   -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
   -- last set `selection_mode`
-  -- Also, we need to handle cases that 
+  -- Also, we need to handle cases that
   -- the value returned from vim.fn.mode()
   -- ends with "v" e.g. {'nov', 'noV', 'v', 'V'}
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
 
-  local valid_chars = {"o", "v", "V"}
+  local valid_chars = { "o", "v", "V" }
   if not vim.tbl_contains(valid_chars, visual_mode) then
     selection_mode = visual_mode
   end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -139,7 +139,7 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- last set `selection_mode`
   -- Also, we need to handle cases that 
   -- the value returned from vim.fn.mode()
-  -- ends with {'nov', 'noV', 'v', 'V'}
+  -- ends with "v" e.g. {'nov', 'noV', 'v', 'V'}
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
 

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -139,7 +139,7 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- last set `selection_mode`
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
-  selection_mode = visual_mode == "o" and selection_mode or visual_mode
+  selection_mode = visual_mode ~= "o" and selection_mode or visual_mode
 
   if selection_mode == "n" then
     selection_mode = "v"

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -1,9 +1,9 @@
 local api = vim.api
-local configs = require "nvim-treesitter.configs"
-local parsers = require "nvim-treesitter.parsers"
+local configs = require("nvim-treesitter.configs")
+local parsers = require("nvim-treesitter.parsers")
 
-local shared = require "nvim-treesitter.textobjects.shared"
-local ts_utils = require "nvim-treesitter.ts_utils"
+local shared = require("nvim-treesitter.textobjects.shared")
+local ts_utils = require("nvim-treesitter.ts_utils")
 
 local M = {}
 
@@ -101,15 +101,15 @@ function M.select_textobject(query_string, query_group, keymap_mode)
   local surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
   local bufnr, textobject = shared.textobject_at_point(query_string, query_group, nil, nil, {
     lookahead = lookahead,
-    lookbehind = lookbehind
+    lookbehind = lookbehind,
   })
   if textobject then
     local selection_mode = M.detect_selection_mode(query_string, keymap_mode)
     if
-        val_or_return(surrounding_whitespace, {
-          query_string = query_string,
-          selection_mode = selection_mode,
-        })
+      val_or_return(surrounding_whitespace, {
+        query_string = query_string,
+        selection_mode = selection_mode,
+      })
     then
       textobject = include_surrounding_whitespace(bufnr, textobject, selection_mode)
     end
@@ -127,7 +127,7 @@ function M.detect_selection_mode(query_string, keymap_mode)
   }
   local method = keymap_to_method[keymap_mode]
 
-  local config = configs.get_module "textobjects.select"
+  local config = configs.get_module("textobjects.select")
   local selection_modes = val_or_return(config.selection_modes, { query_string = query_string, method = method })
   local selection_mode
   if type(selection_modes) == "table" then
@@ -161,7 +161,7 @@ M.keymaps_per_buf = {}
 
 function M.attach(bufnr, lang)
   bufnr = bufnr or api.nvim_get_current_buf()
-  local config = configs.get_module "textobjects.select"
+  local config = configs.get_module("textobjects.select")
   lang = lang or parsers.get_buf_lang(bufnr)
 
   for mapping, query in pairs(config.keymaps) do
@@ -192,7 +192,7 @@ function M.attach(bufnr, lang)
     end
 
     if query_string then
-      for _, keymap_mode in ipairs { "o", "x" } do
+      for _, keymap_mode in ipairs({ "o", "x" }) do
         local cmd = function()
           M.select_textobject(query_string, query_group, keymap_mode)
         end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -99,8 +99,10 @@ function M.select_textobject(query_string, query_group, keymap_mode)
   local lookahead = configs.get_module("textobjects.select").lookahead
   local lookbehind = configs.get_module("textobjects.select").lookbehind
   local surrounding_whitespace = configs.get_module("textobjects.select").include_surrounding_whitespace
-  local bufnr, textobject =
-      shared.textobject_at_point(query_string, query_group, nil, nil, { lookahead = lookahead, lookbehind = lookbehind })
+  local bufnr, textobject = shared.textobject_at_point(query_string, query_group, nil, nil, {
+    lookahead = lookahead,
+    lookbehind = lookbehind
+  })
   if textobject then
     local selection_mode = M.detect_selection_mode(query_string, keymap_mode)
     if


### PR DESCRIPTION
# Issue
When specifying selection modes for query strings like below the selection mode that the user has specified is overwritten by `detect_selection_modes()` `in select.lua`
```
      selection_modes = {
        ["@function.outer"] = 'V', -- linewise
        ["@function.inner"] = 'V', -- linewise
        ["@parameter.outer"] = 'v', -- charwise
        ["@class.outer"] = '<c-v>', -- blockwise
      },
```
In the previose loginc, when selection_mode is 'V'(uppercase), the final return value will be 'v'(lowercase). so we cannot configure the selection mode.