### PR TITLE
fix: swap adjacent node wrong range

### DIFF
--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -310,6 +310,7 @@ function M.next_textobject(node, query_string, query_group, same_parent, overlap
   local search_start, _
   if overlapping_range_ok then
     _, _, search_start = node:start()
+    search_start = search_start + 1
   else
     _, _, search_start = node:end_()
   end
@@ -320,7 +321,7 @@ function M.next_textobject(node, query_string, query_group, same_parent, overlap
     if not same_parent or node:parent() == match.node:parent() then
       local _, _, start = match.node:start()
       local _, _, end_ = match.node:end_()
-      return start > search_start and end_ >= node_end
+      return start >= search_start and end_ >= node_end
     end
   end
   local function scoring_function(match)
@@ -345,7 +346,7 @@ function M.previous_textobject(node, query_string, query_group, same_parent, ove
   local search_end, _
   if overlapping_range_ok then
     _, _, search_end = node:end_()
-    search_end = search_end + 1
+    search_end = search_end - 1
   else
     _, _, search_end = node:start()
   end
@@ -354,7 +355,7 @@ function M.previous_textobject(node, query_string, query_group, same_parent, ove
     if not same_parent or node:parent() == match.node:parent() then
       local _, _, end_ = match.node:end_()
       local _, _, start = match.node:start()
-      return end_ < search_end and start < node_start
+      return end_ <= search_end and start < node_start
     end
   end
 


### PR DESCRIPTION
Fixes #441 

Finding adjacent node deals with treesitter range in the wrong way. Especially, when the end pos and start pos are the same (immediately adjacent).