### PR TITLE
Add additional R assignment textobjects

### DIFF
--- a/queries/r/textobjects.scm
+++ b/queries/r/textobjects.scm
@@ -106,3 +106,17 @@
 
 (equals_assignment
   name: (_) @assignment.inner)
+
+(super_assignment
+  name: (_) @assignment.lhs
+  value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+
+(super_assignment
+  name: (_) @assignment.inner)
+
+(super_right_assignment
+  value: (_) @assignment.inner @assignment.lhs
+  name: (_) @assignment.rhs) @assignment.outer
+
+(super_right_assignment
+  name: (_) @assignment.inner)


### PR DESCRIPTION
I missed the super assignments on the initial PR https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/447, this adds queries for them.