### PR TITLE
fix(dot-repeat): Use '<cmd>...<cr>' style for mapping to enable proper dot repeat

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -191,7 +191,12 @@ function M.attach(bufnr, lang)
           vim.keymap.set,
           { keymap_mode },
           mapping,
-          cmd,
+          string.format(
+            "<cmd>lua require'nvim-treesitter.textobjects.select'.select_textobject('%s','%s','%s')<cr>",
+            query_string,
+            query_group,
+            keymap_mode
+          ),
           { buffer = bufnr, silent = true, remap = false, desc = desc }
         )
         if status then

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -184,9 +184,6 @@ function M.attach(bufnr, lang)
 
     if query_string then
       for _, keymap_mode in ipairs { "o", "x" } do
-        local cmd = function()
-          M.select_textobject(query_string, query_group, keymap_mode)
-        end
         local status, _ = pcall(
           vim.keymap.set,
           { keymap_mode },


### PR DESCRIPTION
At the moment, when using a direct lua function for the key mappings, the "dot-repeat" action does not trigger as expected. For example, `dap` which will  delete a 3 chars parameter, when repeated with `.`, will simply delete 3 chars again, instead of deleting the parameter the cursor is on.

**edit**: Locally, when I try `dVac` (`ac` is "@conditional.outer") then `.` with the old method, I get stuck in an apparent infinite loop. This behaviour is fixed with the new method. I don't know if it is reproducible or if it's due to my config. 