### PR TITLE
feat: [scala] Update function body node type

### DIFF
--- a/queries/scala/textobjects.scm
+++ b/queries/scala/textobjects.scm
@@ -5,7 +5,7 @@
   body: (template_body)? @class.inner) @class.outer
 
 (function_definition
-  body: (expression) @function.inner) @function.outer
+  body: [(indented_block) (expression) (indented_cases) (block)] @function.inner) @function.outer
 
 (parameter
   name: (identifier) @parameter.inner) @parameter.outer


### PR DESCRIPTION
According to the [latest](https://github.com/tree-sitter/tree-sitter-scala/commit/2d0e6b8c14236ead27aa86236d2d302fbdf5c24b) treesitter grammar for scala function is defined as:

```
function_definition: $ => seq(
      repeat($.annotation),
      optional($.modifiers),
      'def',
      $._function_constructor,
      choice(
        seq('=', field('body', $._indentable_expression)),
        field('body', $.block)
      )
    )
```

where `_indentable_expression` is:

```
_indentable_expression: $ => choice(
      $.indented_block,
      $.indented_cases,
      $.expression,
    )
```