### PR TITLE
queries: add support for norg (with query copied from neorg's own folds.scm

### DIFF
--- a/queries/norg/textobjects.scm
+++ b/queries/norg/textobjects.scm
@@ -1,0 +1,13 @@
+(ranged_verbatim_tag
+    name: (tag_name) @_name
+    (#eq? @_name "document.meta")
+) @fold
+
+[
+    (heading1)
+    (heading2)
+    (heading3)
+    (heading4)
+    (heading5)
+    (heading6)
+] @fold


### PR DESCRIPTION
Hi. Please consider this small addition for the `.norg` filetype. `.norg` is the filetype created for the [Neorg](https://github.com/nvim-neorg/neorg) project, and Neorg is a `neovim` plugin for note taking and task/project management. It's similar to Emacs' `org-mode`, but the syntax is quite different. Neorg uses treesitter to parse and manipulate `.norg` files.

Being a structured markup language, `.norg`'s tree features nested `heading[1-6]`s. These headings are already referenced in `fold` queries, and it would be straightforward & valuable to be able to reuse these queries for text objects.

It's a very simple use case, but it's very handy to be able to yank headings (and their content) at any level like this. It's working well for me.

For reference:
* The treesitter parser for `.norg` is here: https://github.com/nvim-neorg/tree-sitter-norg
* The `.norg` specification is here: https://github.com/nvim-neorg/norg-specs
* The provided query came directly from this file in the `neorg` project: https://github.com/nvim-neorg/neorg/blob/main/queries/norg/folds.scm

Thanks