### PR TITLE
fix(go): update definition of `@parameter`

### DIFF
--- a/queries/go/textobjects.scm
+++ b/queries/go/textobjects.scm
@@ -76,12 +76,12 @@
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (parameter_declaration
-  (identifier)
-  (identifier) @parameter.inner)
+  name: (identifier)
+  type: (_) @parameter.inner)
 
 (parameter_declaration
-  (identifier) @parameter.inner
-  (identifier))
+  name: (identifier) @parameter.inner
+  type: (_))
 
 (parameter_list
   "," @_start .


### PR DESCRIPTION
Fixes https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/460

Definition `parameter_declaration`: https://github.com/tree-sitter/tree-sitter-go/blob/7cccc30535a40da07092626031120ae6b36202d7/grammar.js#L236
