### PR TITLE
queries/go: fix queries for parameter.inner

### DIFF
--- a/queries/go/textobjects.scm
+++ b/queries/go/textobjects.scm
@@ -77,11 +77,11 @@
 
 (parameter_declaration
   name: (identifier)
-  type: (_) @parameter.inner)
+  type: (_)) @parameter.inner
 
 (parameter_declaration
-  name: (identifier) @parameter.inner
-  type: (_))
+  name: (identifier) 
+  type: (_)) @parameter.inner
 
 (parameter_list
   "," @_start .


### PR DESCRIPTION
@parameter.inner should capture the whole parameter, not just the identifier or the type.

For example:

```go
func doThing(x, y int) {{}
```

- `x` is @parameter.inner
- `y int` is @parameter.inner