### PR TITLE
fix: check if `last_move` exists before repeating opposite move

### DIFF
--- a/lua/nvim-treesitter/textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter/textobjects/repeatable_move.lua
@@ -111,7 +111,7 @@ M.repeat_last_move = function(opts_extend)
 end
 
 M.repeat_last_move_opposite = function()
-  return M.repeat_last_move { forward = not M.last_move.opts.forward }
+  return M.last_move and M.repeat_last_move { forward = not M.last_move.opts.forward }
 end
 
 M.repeat_last_move_next = function()


### PR DESCRIPTION
This fixes the following error from being thrown when "original" vim repeat keybinds are set and `repeat_last_move_opposite` is called before `repeat_last_move`:
```lua
    -- vim way: ; goes to the direction you were moving.
    vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)
    vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_opposite)
```

<details>
<summary>Error Message</summary>


```
E5108: Error executing lua: ...ects/lua/nvim-treesitter/textobjects/repeatable_move.lua:114: attempt to index field 'last_move' (a nil value)
stack traceback:
...ects/lua/nvim-treesitter/textobjects/repeatable_move.lua:114: in function <...ects/lua/nvim-treesitter/textobjects/repeatable_move.lua:113>
```



</details>