### PR TITLE
feat(rust): add `@parameter` for type

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -133,6 +133,13 @@
   . ","? @_end
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
+((tuple_type
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((tuple_type
+  . (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
 (struct_item
   body: (field_declaration_list
     "," @_start

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -95,6 +95,13 @@
   . (parameter) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
+((parameters
+  "," @_start . (type_identifier) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((parameters
+  . (type_identifier) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
 ((type_parameters
   "," @_start . (_) @parameter.inner)
  (#make-range! "parameter.outer" @_start @parameter.inner))


### PR DESCRIPTION
`type_identifier` in `parameters` matches with parameters in function pointer types such as each `String` below:

```rust
type foo = fn(String, String) -> ();
```

`_` in `tuple_type` matches with types in tuple such as each `String` below:

```rust
type foo = (String, String);
```