### PR TITLE
feat(rust): Add `token_tree` to `@parameter.inner`

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -171,6 +171,13 @@
   . (_) @parameter.inner . ","? @_end)
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
+((token_tree
+  "," @_start . (_) @parameter.inner)
+ (#make-range! "parameter.outer" @_start @parameter.inner))
+((token_tree
+  . (_) @parameter.inner . ","? @_end)
+ (#make-range! "parameter.outer" @parameter.inner @_end))
+
 (scoped_use_list
   list: (use_list "," @_start . (_) @parameter.inner
     (#make-range! "parameter.outer" @_start @parameter.inner)))


### PR DESCRIPTION
Related to https://github.com/nvim-treesitter/nvim-treesitter-textobjects/pull/2

```rust
  #[derive(Debug, Clone)]
  struct Test;
```

textobject around `Debug` and `Clone`.