### PR TITLE
Fix/ js inner without curly braces

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -52,8 +52,8 @@
   (#make-range! "loop.inner" @_start @_end))) @loop.outer
 
 (if_statement
-  consequence: (_)? @conditional.inner
-  alternative: (_)? @conditional.inner) @conditional.outer
+  consequence: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"
+  (#make-range! "conditional.inner" @_start @_end))) @conditional.outer
 
 (switch_statement
   body: (_)? @conditional.inner) @conditional.outer

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -36,16 +36,20 @@
   (class_declaration) @class.outer) @class.outer.start
 
 (for_in_statement
-  body: (_)? @loop.inner) @loop.outer
+  body: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"
+  (#make-range! "loop.inner" @_start @_end))) @loop.outer
 
 (for_statement
-  body: (_)? @loop.inner) @loop.outer
+  body: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"
+  (#make-range! "loop.inner" @_start @_end))) @loop.outer
 
 (while_statement
-  body: (_)? @loop.inner) @loop.outer
+  body: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"
+  (#make-range! "loop.inner" @_start @_end))) @loop.outer
 
 (do_statement
-  body: (_)? @loop.inner) @loop.outer
+  body: (statement_block . "{" . (_) @_start @_end (_)? @_end . "}"
+  (#make-range! "loop.inner" @_start @_end))) @loop.outer
 
 (if_statement
   consequence: (_)? @conditional.inner


### PR DESCRIPTION
Following [some posts](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/112) I found about removing the curly braces of inner selections.
Like for functions and methods it feels logical that it would behave the same for other blocks.

I updated the ecma text objects to select only the inner part for loops and if statements.
I tested locally it seems working nicely, let me know if I made some mistakes, I basically reused code I found. (not familiar with the syntax).