### PR TITLE
feat: add astro textobjects

### DIFF
--- a/queries/astro/textobjects.scm
+++ b/queries/astro/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: html


### PR DESCRIPTION
Astro's textobjects are the same as HTML's textobjects, so it's just inherited from HTML.

Fixes https://github.com/virchau13/tree-sitter-astro/issues/19.