### PR TITLE
Add assignment textobjects for JS/TS object keys/values

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -125,3 +125,8 @@
 
 (variable_declarator
  name: (_) @assignment.inner)
+
+(object
+  (pair
+    key: (_) @assignment.lhs
+    value: (_) @assignment.inner @assignment.rhs) @assignment.outer)


### PR DESCRIPTION
One thing I've found very useful in the last couple of weeks is adding object keys/values to the `@assignment.lhs`/`@assignment.rhs` textobjects for JavaScript / Typescript.

Here's a preview:
https://github.com/nvim-treesitter/nvim-treesitter-textobjects/assets/543561/a998c126-e2b4-452c-9871-0c9cb8dfb622

Even though it broadens the definition of assignment, it feels very intuitive after you take it for a quick spin.