### PR TITLE
feat(ecma): `@call` object for constructor calls

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -69,6 +69,12 @@
   arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"
   (#make-range! "call.inner" @_start @_end)))
 
+((new_expression
+  constructor: (identifier) @_cons
+  arguments: (arguments . "(" . (_) @_start (_)? @_end . ")") @_args)
+ (#make-range! "call.outer" @_cons @_args)
+ (#make-range! "call.inner" @_start @_end))
+
 ;; blocks
 (_ (statement_block) @block.inner) @block.outer
 


### PR DESCRIPTION
Provides appropriate `@call.inner` and `@call.outer` text objects for object constructors, e.g. `new MyObject(5, 'hi')`