### PR TITLE
feat(rust): Add `macro_invocation` as a type of `@call.outer`.

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -71,6 +71,8 @@
 
 ;; calls
 (macro_invocation) @call.outer
+(macro_invocation (token_tree . "(" . (_) @_start (_)? @_end . ")"
+  (#make-range! "call.inner" @_start @_end)))
 (call_expression) @call.outer
 (call_expression
   arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -70,6 +70,7 @@
 (unsafe_block (_)? @block.inner) @block.outer
 
 ;; calls
+(macro_invocation) @call.outer
 (call_expression) @call.outer
 (call_expression
   arguments: (arguments . "(" . (_) @_start (_)? @_end . ")"


### PR DESCRIPTION
To my understanding, macro invocations should be considered a type of function call. Would also resolve [this issue](https://github.com/kylechui/nvim-surround/issues/290#issuecomment-1854629989).