### PR TITLE
fix(select.lua): Fix condition for 'visual_mode' selection

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -139,7 +139,7 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- last set `selection_mode`
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
-  selection_mode = visual_mode == "o" and selection_mode or visual_mode
+  selection_mode = visual_mode == "o" and visual_mode or selection_mode
 
   if selection_mode == "n" then
     selection_mode = "v"

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -139,11 +139,8 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- last set `selection_mode`
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
-  selection_mode = visual_mode == "o" and visual_mode or selection_mode
-
-  if selection_mode == "n" then
-    selection_mode = "v"
-  end
+  vim.notify(visual_mode)
+  selection_mode = visual_mode == "n" and "v" or selection_mode
 
   return selection_mode
 end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -134,12 +134,9 @@ function M.detect_selection_mode(query_string, keymap_mode)
     selection_mode = selection_modes or "v"
   end
 
-  -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
-  -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
-  -- last set `selection_mode`
-  local visual_mode = vim.fn.mode(1)
-  visual_mode = visual_mode:sub(#visual_mode)
-  selection_mode = visual_mode == "n" and "v" or selection_mode
+  if selection_mode == "n" then
+    selection_mode = "v"
+  end
 
   return selection_mode
 end

--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -139,7 +139,6 @@ function M.detect_selection_mode(query_string, keymap_mode)
   -- last set `selection_mode`
   local visual_mode = vim.fn.mode(1)
   visual_mode = visual_mode:sub(#visual_mode)
-  vim.notify(visual_mode)
   selection_mode = visual_mode == "n" and "v" or selection_mode
 
   return selection_mode


### PR DESCRIPTION
The value of `config.selection_modes` is only considered when we are in `operation pending mode`. The example below describes the issue that this PR can solve.

1. Set `config.selection_modes["@function.outer"] = "V"`
2. Type `"vaf"` in normal mode.
3. We get pure `"v"` mode enabled instead of `"V"`

In my opinion, we should also consider the value of `config.selection_modes` in the case of `{"v", "V", "<C-v>"}`. Please kindly review the description, and I would really appreciate it if I could get any feedback.

Fixes #515