### PR TITLE
Add assignment textobjects to CSS

### DIFF
--- a/queries/css/textobjects.scm
+++ b/queries/css/textobjects.scm
@@ -3,3 +3,8 @@
   (float_value)
   (color_value)
 ] @number.inner
+
+(declaration
+  (property_name) @assignment.lhs
+  (_) @assignment.inner @assignment.rhs
+) @assignment.outer

--- a/queries/css/textobjects.scm
+++ b/queries/css/textobjects.scm
@@ -6,5 +6,11 @@
 
 (declaration
   (property_name) @assignment.lhs
-  (_) @assignment.inner @assignment.rhs
+  . ":" . (_) @_start (_)? @_end . ";"
+  (#make-range! "assignment.inner" @_start @_end)
+  (#make-range! "assignment.rhs" @_start @_end)
 ) @assignment.outer
+
+(declaration
+  (property_name) @assignment.inner
+)


### PR DESCRIPTION
These are the property/value textobjects for CSS.

Selecting property (key): 
![image](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/assets/543561/a420e816-5496-48df-b90c-7ca456010c41)

Selecting value:
![image](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/assets/543561/f7a32e8f-530d-4328-9aef-f07e71c46f19)

However there's an edge case which I don't know how to properly handle. It has to do with some properties having multiple values. With the current implementation, only one of the values is selected (the closest one).

`background-image`:
![image](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/assets/543561/1fdb7847-2c59-4408-b479-d1c73498a815)

`transition`:
![image](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/assets/543561/a0eb4c47-eb2c-4e75-bff9-dd654d10c947)

As a workaround we can make `@assignment.rhs` and `@assignment.inner` (which seem to be synonyms in most language queries) to differ slightly and have `@assignment.rhs` capture all the values and `@assignment.inner` capture one value only.

Having the following keymaps works very intuitively for this setup:
``` lua
['ik'] = '@assignment.lhs', -- select the key
['ak'] = '@assignment.outer', -- select the whole assignment
['iv'] = '@assignment.inner', -- select the value (a single value, if multiple are available)
['av'] = '@assignment.rhs', -- select the value (the whole value, if multiple are available)
```

This query is very close, but I struggle to exclude the `:` and `;` characters from the range via `#offset!`.
```scm
(declaration
  (property_name) @assignment.lhs
  (":") @_start (#offset! @_start 0 1 0 1)
  (_) @assignment.inner
  (";") @_end (#offset! @_end 0 -1 0 -1)
  (#make-range! "assignment.rhs" @_start @_end)
) @assignment.outer
```