### PR TITLE
revert: Fix condition for 'visual_mode' selection"

### DIFF
--- a/lua/nvim-treesitter/textobjects/select.lua
+++ b/lua/nvim-treesitter/textobjects/select.lua
@@ -134,6 +134,13 @@ function M.detect_selection_mode(query_string, keymap_mode)
     selection_mode = selection_modes or "v"
   end
 
+  -- According to "mode()" mapping, if we are in operator pending mode or visual mode,
+  -- then last char is {v,V,<C-v>}, exept for "no", which is "o", in which case we honor
+  -- last set `selection_mode`
+  local visual_mode = vim.fn.mode(1)
+  visual_mode = visual_mode:sub(#visual_mode)
+  selection_mode = visual_mode == "o" and selection_mode or visual_mode
+
   if selection_mode == "n" then
     selection_mode = "v"
   end


### PR DESCRIPTION
Reverts nvim-treesitter/nvim-treesitter-textobjects#539