### PR TITLE
fix(lua): ignore comments for table inner param

### DIFF
--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -76,8 +76,8 @@
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (table_constructor
-  . (_) @parameter.inner
-  . ","? @_end
+  (field) @parameter.inner
+  ","? @_end
   (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (arguments
@@ -86,11 +86,6 @@
  (#make-range! "parameter.outer" @_start @parameter.inner))
 
 (parameters
-  "," @_start
-  . (_) @parameter.inner
- (#make-range! "parameter.outer" @_start @parameter.inner))
-
-(table_constructor
   "," @_start
   . (_) @parameter.inner
  (#make-range! "parameter.outer" @_start @parameter.inner))


### PR DESCRIPTION
This PR makes it so that `(comment)` nodes are ignored when recognizing `@parameter.(inner|outer)` textobjects in Lua tables. We now only capture `(field)` nodes. This helps with swapping and deletion, when doing both actions while having comments inbetween fields, currently the behavior is quite buggy because the `(_)` query will capture comments, and improperly since they do not have the associated `","` node. This PR also removes a query to simplify and improve captures, and it is not necessary because tables (unlike the similar parameter and argument queries) *can* have trailing commas, so we don't need to create any finnicky captures. To test, notice the difference when swapping `@parameter.inner` with something like the following:
```lua
local swapme = {
  -- comment
  'fieldhere',
  'anotherfield',
  -- another comment
  'a final field',
}
```