### PR TITLE
fix(swap): preserve swapped nodes' range metadata

### DIFF
--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -332,7 +332,7 @@ function M.next_textobject(node, query_string, query_group, same_parent, overlap
 
   local next_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
 
-  return next_node and next_node.node
+  return next_node and next_node.node, next_node.metadata
 end
 
 function M.previous_textobject(node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
@@ -367,7 +367,7 @@ function M.previous_textobject(node, query_string, query_group, same_parent, ove
 
   local previous_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
 
-  return previous_node and previous_node.node
+  return previous_node and previous_node.node, previous_node.metadata
 end
 
 return M

--- a/lua/nvim-treesitter/textobjects/swap.lua
+++ b/lua/nvim-treesitter/textobjects/swap.lua
@@ -27,9 +27,9 @@ local function swap_textobject(query_strings_regex, query_group, direction)
   local same_parent = true
   for _ = 1, math.abs(direction), step do
     local forward = direction > 0
-    local adjacent =
+    local adjacent, metadata =
       shared.get_adjacent(forward, node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
-    ts_utils.swap_nodes(textobject_range, adjacent, bufnr, "yes, set cursor!")
+    ts_utils.swap_nodes(textobject_range, metadata and metadata.range or adjacent, bufnr, "yes, set cursor!")
   end
 end
 


### PR DESCRIPTION
Right now the `adjacent` node to be swapped does not have its range metadata preserved properly. This results in weird asymmetrical behavior when swapping nodes that have their own capture ranges, such as the following:
```scheme
((list_item) @swappable
  (#trim! @swappable))
```
Currently, such swaps will include a blank new line at the end, but only when swapping from the second to last list item to the last list item (the reverse direction is unaffected; this also only applies when a new line follows the list). This PR fixes that by preserving the range.