### PR TITLE
fix(latex): proper function call text objects

### DIFF
--- a/queries/latex/textobjects.scm
+++ b/queries/latex/textobjects.scm
@@ -16,7 +16,28 @@
 
 [
   (generic_command)
-] @statement.outer
+  (text_mode)
+] @call.outer
+
+(text_mode
+  (curly_group
+    "{"
+    .
+    (_) @_start
+    (_)? @_end
+    .
+    "}")
+  (#make-range! "call.inner" @_start @_end))
+
+(generic_command
+  (curly_group
+    "{"
+    .
+    (_) @_start
+    (_)? @_end
+    .
+    "}")
+  (#make-range! "call.inner" @_start @_end))
 
 [
   (chapter)


### PR DESCRIPTION
Gives `@call.(outer|inner)` text objects to LaTeX functions, to closer match the highlights. Extends the objects to text functions, and their inner content.