### PR TITLE
feat(toml): Add @parameter.inner and @parameter.outer

### DIFF
--- a/queries/toml/textobjects.scm
+++ b/queries/toml/textobjects.scm
@@ -2,3 +2,31 @@
   (integer)
   (float)
 ] @number.inner
+
+((table
+    (pair) @parameter.inner @parameter.outer
+  ))
+
+((inline_table
+    "," @_start .
+    (_) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((inline_table
+    . (_) @parameter.inner
+    . ","? @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+((array
+    "," @_start .
+    (_) @parameter.inner
+  )
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((array
+    . (_) @parameter.inner
+    . ","? @_end
+  )
+  (#make-range! "parameter.outer" @parameter.inner @_end))


### PR DESCRIPTION
Includes array elements, key-val pair in inline tables and key-val pairs in normal tables.