### PR TITLE
queries/fennel: update queries for the new grammar

### DIFF
--- a/queries/fennel/textobjects.scm
+++ b/queries/fennel/textobjects.scm
@@ -1,52 +1,34 @@
-
 ; https://fennel-lang.org/reference
 
 (comment) @comment.outer
 
 (_ . "(" ")" .) @statement.outer
 
-; functions
-((fn . name: (_)? . (parameters) . docstring: (_)? . (_) @_start . (_)* . (_)? @_end .)
- (#make-range! "function.inner" @_start @_end)) @function.outer
-
-((lambda . name: (_)? . (parameters) . docstring: (_)? . (_) @_start . (_)* . (_)? @_end .)
- (#make-range! "function.inner" @_start @_end)) @function.outer
-
-(hashfn ["#" "hashfn"] @function.outer.start (_) @function.inner) @function.outer
-
-; parameters
-(parameters (_) @parameter.inner)
-(parameters (_) @parameter.outer)
+; functions & parameters
+(list .
+  (symbol) @_fn 
+  (symbol)? @_fn_name 
+  (sequence
+    (_) @parameter.inner) 
+  (_)* @function.inner
+  (#any-of? @_fn "fn" "lambda" "λ")) @function.outer 
 
 ; call
-((list . [(multi_symbol) (symbol)] @_sym . (_) @_start . (_)* . (_)? @_end .)
- (#make-range! "call.inner" @_start @_end)
- (#not-any-of? @_sym "if" "do" "while" "for" "let" "when")) @call.outer
+(list .
+  (symbol) @_fn_name
+  (_)* @call.inner
+  (#not-any-of? @_fn_name "if" "do" "while" "for" "each" "let" "when" "fn")) @call.outer
 
 ; conditionals
-((list . ((symbol) @_if (#any-of? @_if "if" "when")) . (_) .
-  (_) @_start .
-  (_)* .
-  (_)? @_end .)
- (#make-range! "conditional.inner" @_start @_end)) @conditional.outer
-
+(list
+  (symbol) @_cond
+  (_)
+  (_)* @conditional.inner
+  (#any-of? @_cond "if" "when")) @conditional.outer
 
 ; loops
-((for . (for_clause) .
-  (_) @_start .
-  (_)* .
-  (_)? @_end .)
- (#make-range! "loop.inner" @_start @_end)) @loop.outer
-
-((each . (_) .
-  (_) @_start .
-  (_)* .
-  (_)? @_end .)
- (#make-range! "loop.inner" @_start @_end)) @loop.outer
-
-((list . ((symbol) @_while (#eq? @_while "while")) . (_) .
-  (_) @_start .
-  (_)* .
-  (_)? @_end .)
- (#make-range! "loop.inner" @_start @_end)) @loop.outer
-
+(list .
+  (symbol) @_sym .
+  (_) .
+  (_)* @loop.inner
+  (#any-of? @_sym "each" "while" "for")) @loop.outer


### PR DESCRIPTION
Updating queries to account for the new parser introduced in nvim-treesitter/nvim-treesitter#6132.