### PR TITLE
feat(c): add text objects for statement conditions

### DIFF
--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -30,6 +30,21 @@
 
 (if_statement) @conditional.outer
 
+(if_statement
+  condition: (_) @conditional.inner
+  (#offset! @conditional.inner 0 1 0 -1))
+
+(while_statement
+  condition: (_) @conditional.inner
+  (#offset! @conditional.inner 0 1 0 -1))
+
+(do_statement
+  condition: (_) @conditional.inner
+  (#offset! @conditional.inner 0 1 0 -1))
+
+(for_statement
+  condition: (_) @conditional.inner)
+
 ; loops
 (while_statement) @loop.outer
 (while_statement


### PR DESCRIPTION
Allows `@conditional.inner` to include not just the body of e.g. an if statement, but also the condition itself (and conditions for while loops, do while, etc.)