### PR TITLE
Patch 1

### DIFF
--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -332,7 +332,7 @@ function M.next_textobject(node, query_string, query_group, same_parent, overlap
 
   local next_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
 
-  return next_node and next_node.node, next_node.metadata
+  return next_node and next_node.node, next_node and next_node.metadata
 end
 
 function M.previous_textobject(node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)

--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -331,8 +331,11 @@ function M.next_textobject(node, query_string, query_group, same_parent, overlap
   end
 
   local next_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
+  if not previous_node then
+    return
+  end
 
-  return next_node and next_node.node, next_node and next_node.metadata
+  return next_node.node, next_node.metadata
 end
 
 function M.previous_textobject(node, query_string, query_group, same_parent, overlapping_range_ok, bufnr)
@@ -366,8 +369,11 @@ function M.previous_textobject(node, query_string, query_group, same_parent, ove
   end
 
   local previous_node = queries.find_best_match(bufnr, query_string, query_group, filter_function, scoring_function)
-
-  return previous_node and previous_node.node, previous_node.metadata
+  if not previous_node then
+    return
+  end
+  
+  return previous_node.node, previous_node.metadata
 end
 
 return M


### PR DESCRIPTION
In `M.next_textobject`:
```lua
next_node and next_node.node, next_node.metadata
```
Is actually:
```lua
(next_node and next_node.node), next_node.metadata
```
`next_node.metadata` would be `nil.metadata` when next_node is nil, resulting in `attempt to index local 'next_node' (a nil value)` when I trying to use swap_next at the last argument.
`M.previous_textobject` has the same issue too. We'd better use an early return instead.