### PR TITLE
feat(c): assignment operator for c

### DIFF
--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -116,3 +116,8 @@
 (declaration
   type: (primitive_type)
   declarator: (_) @assignment.inner)
+
+(expression_statement
+  (assignment_expression
+    left: (_) @assignment.lhs
+    right: (_) @assignment.rhs) @assignment.inner) @assignment.outer

--- a/queries/c/textobjects.scm
+++ b/queries/c/textobjects.scm
@@ -107,3 +107,12 @@
  (#make-range! "parameter.outer" @parameter.inner @_end))
 
 (number_literal) @number.inner
+
+(declaration
+  declarator: (init_declarator
+    declarator: (_) @assignment.lhs
+    value: (_) @assignment.rhs) @assignment.inner) @assignment.outer
+
+(declaration
+  type: (primitive_type)
+  declarator: (_) @assignment.inner)


### PR DESCRIPTION
Problem : #585 
Solution : 
- Assignment inner/outer/left/right now fully works on declaration such as `int a = 3` and definitions such as `int a = 10`
- It does also work on expression_statement such as `a = 0` (notice there is no type here)