### PR TITLE
rust: add self_parameter query

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -216,6 +216,19 @@
 ((parameters
   "," @_start
   .
+  (self_parameter) @parameter.inner)
+  (#make-range! "parameter.outer" @_start @parameter.inner))
+
+((parameters
+  .
+  (self_parameter) @parameter.inner
+  .
+  ","? @_end)
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+((parameters
+  "," @_start
+  .
   (parameter) @parameter.inner)
   (#make-range! "parameter.outer" @_start @parameter.inner))
 


### PR DESCRIPTION
Adds support for the `self` param.