### PR TITLE
fix(haskell): update queries for new parser

### DIFF
--- a/queries/haskell/textobjects.scm
+++ b/queries/haskell/textobjects.scm
@@ -1,6 +1,6 @@
-((exp_apply
+((apply
   .
-  (exp_name)
+  (name)
   .
   (_) @_start
   .
@@ -9,13 +9,20 @@
   (_)? @_end .)
   (#make-range! "call.inner" @_start @_end)) @call.outer
 
-(exp_infix
+(infix
   (_)
   (variable)
   (_)) @call.outer
 
-(function
-  rhs: (_) @function.inner) @function.outer
+(decl/function) @function.outer
+
+(decl/function
+  patterns: (_)
+  .
+  match: (_) @_start
+  match: (_)? @_end
+  .
+  (#make-range! "function.inner" @_start @_end))
 
 ; also treat function signature as @function.outer
 (signature) @function.outer
@@ -23,36 +30,35 @@
 (class) @class.outer
 
 (class
-  (class_body
-    (where)
-    _ @class.inner))
+  "where"
+  _ @class.inner)
 
 (instance
-  (where)?
+  "where"?
   .
   _ @class.inner) @class.outer
 
 (comment) @comment.outer
 
-(exp_cond) @conditional.outer
+(expression/conditional) @conditional.outer
 
-(exp_cond
+(expression/conditional
   (_) @conditional.inner)
 
 ; e.g. forM [1..10] $ \i -> do...
-(exp_infix
-  (exp_apply
-    (exp_name) @_name
+(infix
+  (apply
+    (name) @_name
     (#any-of? @_name "for" "for_" "forM" "forM_"))
   (operator) @_op
   (#eq? @_op "$")
-  (exp_lambda
+  (lambda
     (_)
     (_) @loop.inner)) @loop.outer
 
 ; e.g. forM [1..10] print
-(exp_apply
-  (exp_name) @_name
+(apply
+  (name) @_name
   (#any-of? @_name "for" "for_" "forM" "forM_")
   (_)
   (_) @loop.inner) @loop.outer
@@ -65,35 +71,35 @@
 ; e.g. func mb@(Just x)
 (function
   (patterns
-    (pat_parens
+    (parens
       (_) @parameter.inner)))
 
 (function
   (patterns
-    (pat_as
-      (pat_parens
+    (as
+      (parens
         (_) @parameter.inner))))
 
 (signature
   (context
-    (fun
-      (type_apply) @parameter.inner)))
+    (function
+      (type/apply) @parameter.inner)))
 
 (signature
   (context
-    (fun
-      (type_name) @parameter.inner)))
+    (function
+      (type/name) @parameter.inner)))
 
 (signature
-  (fun
-    (type_apply) @parameter.inner))
+  (function
+    (type/apply) @parameter.inner))
 
 (signature
-  (fun
-    (type_name) @parameter.inner))
+  (function
+    (type/name) @parameter.inner))
 
 (signature
-  (type_apply) @parameter.inner)
+  (type/apply) @parameter.inner)
 
 (signature
-  (type_name) @parameter.inner)
+  (type/name) @parameter.inner)


### PR DESCRIPTION
The parser had a rewrite giving lots of invalid nodes. This fixes all the errors (but maybe too lazily in some cases? not 100% confident about these changes so hopefully someone can confirm they are valid)