### PR TITLE
fix(c_sharp):  Rename for_each_statement to foreach_statement

### DIFF
--- a/queries/c_sharp/textobjects.scm
+++ b/queries/c_sharp/textobjects.scm
@@ -64,7 +64,7 @@
 (for_statement
   body: (_) @loop.inner) @loop.outer
 
-(for_each_statement
+(foreach_statement
   body: (_) @loop.inner) @loop.outer
 
 (do_statement


### PR DESCRIPTION
It appears that `for_each_statement` was renamed to `foreach_statement`, which was causing neovim to throw errors.

https://github.com/tree-sitter/tree-sitter-c-sharp/commit/afe8bb1932b8d73cd23b9c8d8fdf668166212d47
https://github.com/nvim-treesitter/nvim-treesitter/commit/6587d8e6942b8d2146d61bab4c4acff9dec5ae59

This change fixed it for me :).