### PR TITLE
FIX: error on startup in nightly

### DIFF
--- a/lua/nvim-treesitter/textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter/textobjects/repeatable_move.lua
@@ -249,27 +249,35 @@ end
 M.commands = {
   TSTextobjectRepeatLastMove = {
     run = M.repeat_last_move,
+    args = {},
   },
   TSTextobjectRepeatLastMoveOpposite = {
     run = M.repeat_last_move_opposite,
+    args = {},
   },
   TSTextobjectRepeatLastMoveNext = {
     run = M.repeat_last_move_next,
+    args = {},
   },
   TSTextobjectRepeatLastMovePrevious = {
     run = M.repeat_last_move_previous,
+    args = {},
   },
   TSTextobjectBuiltinf = {
     run = M.builtin_f,
+    args = {},
   },
   TSTextobjectBuiltinF = {
     run = M.builtin_F,
+    args = {},
   },
   TSTextobjectBuiltint = {
     run = M.builtin_t,
+    args = {},
   },
   TSTextobjectBuiltinT = {
     run = M.builtin_T,
+    args = {},
   },
 }
 


### PR DESCRIPTION
This PR fixes an error introduced by [an update to `nvim-treesitter`](https://github.com/nvim-treesitter/nvim-treesitter/pull/6647) that adds a compatibility shim for neovim versions > 0.10. Unfortunately the use of `vim.iter:flatten` seems to error out when `nil` is passed in as one element in a list-like table. Note the error:
```
vim/_editor.lua:0: nvim_exec2()../home/dgreene/.local/share/nvim/lazy/nvim-treesitter-textobjects/plugin/nvim-treesitter-textobjects.vim, line 3: Vim(lua):E5108: Error executing lua ...nightly/nvim-linux64/share/nvim/runtime/lua/vim/iter.lua:236: flatten() requires a list-like table
stack traceback:
	[C]: in function 'error'
	...nightly/nvim-linux64/share/nvim/runtime/lua/vim/iter.lua:236: in function 'flatten'
	...nvim/lazy/nvim-treesitter/lua/nvim-treesitter/compat.lua:33: in function 'flatten'
	.../nvim/lazy/nvim-treesitter/lua/nvim-treesitter/utils.lua:86: in function 'setup_commands'
	...eesitter-textobjects/lua/nvim-treesitter-textobjects.lua:70: in function 'init'
	[string ":lua"]:1: in main chunk
	[C]: in function 'nvim_exec2'
	vim/_editor.lua: in function 'cmd'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:485: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:484>
	[C]: in function 'xpcall'
	.../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:113: in function 'try'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:484: in function 'source'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:443: in function 'source_runtime'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:411: in function 'packadd'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:346: in function '_load'
	...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
	...cal/share/nvim/lazy/lazy.nvim/lua/lazy/view/commands.lua:55: in function 'load'
	...are/nvim/lazy/LazyVim/lua/lazyvim/plugins/treesitter.lua:89: in function <...are/nvim/lazy/LazyVim/lua/lazyvim/plugins/treesitter.lua:88>

# stacktrace:
  - vim/_editor.lua:0 _in_ **cmd**
  - /LazyVim/lua/lazyvim/plugins/treesitter.lua:89
```
Explicitly specifying `args` as an empty table causes `flatten` to behave as expected.