### PR TITLE
Added islist compatibility function for Neovim 0.12+

### DIFF
--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -6,6 +6,9 @@ local M = {}
 
 local floating_win
 
+-- NOTE: This can be replaced with `vim.islist` once Neovim 0.9 support is dropped
+local islist = vim.fn.has "nvim-0.10" == 1 and vim.islist or vim.tbl_islist
+
 -- peeking is not interruptive so it is okay to use in visual mode.
 -- in fact, visual mode peeking is very helpful because you may not want
 -- to jump to the definition.
@@ -69,7 +72,7 @@ function M.make_preview_location_callback(query_string, query_group, context)
       return
     end
 
-    if vim.tbl_islist(result) then
+    if islist(result) then
       result = result[1]
     end
     local uri = result.uri or result.targetUri


### PR DESCRIPTION
See: https://neovim.io/doc/user/deprecated.html#deprecated-0.10

`Deprecated vim.tbl_islist() Use vim.islist() instead.`
