### PR TITLE
ci(lint): use query parser from nvim-treesitter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,16 +34,20 @@ jobs:
   format-queries:
     name: Lint queries
     runs-on: ubuntu-latest
+    env:
+      NVIM_TAG: stable
     steps:
       - uses: actions/checkout@v4
       - name: Prepare
         run: |
-          wget https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
-          tar -zxf nvim-linux64.tar.gz
-          sudo ln -s "$PWD"/nvim-linux64/bin/nvim /usr/local/bin
+          bash ./scripts/ci-install-ubuntu-latest.sh
           wget -P scripts/ https://raw.githubusercontent.com/nvim-treesitter/nvim-treesitter/main/scripts/format-queries.lua
+          mkdir -p ~/.local/share/nvim/site/pack/nvim-treesitter/start
+          cd ~/.local/share/nvim/site/pack/nvim-treesitter/start
+          git clone https://github.com/nvim-treesitter/nvim-treesitter.git
 
       - name: Lint
         run: |
+          nvim --headless -c "TSInstallSync query" -c "q"
           nvim -l scripts/format-queries.lua queries
           git diff --exit-code

--- a/scripts/ci-install-ubuntu-latest.sh
+++ b/scripts/ci-install-ubuntu-latest.sh
@@ -1,6 +1,6 @@
-wget https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz
+wget "https://github.com/neovim/neovim/releases/download/${NVIM_TAG}/nvim-linux64.tar.gz"
 tar -zxf nvim-linux64.tar.gz
-sudo ln -s $(pwd)/nvim-linux64/bin/nvim /usr/local/bin
-rm -rf $(pwd)/nvim-linux64/lib/nvim/parser
+sudo ln -s "$(pwd)/nvim-linux64/bin/nvim" /usr/local/bin
+rm -rf "$(pwd)/nvim-linux64/lib/nvim/parser"
 mkdir -p ~/.local/share/nvim/site/pack/ci/opt
-ln -s $(pwd) ~/.local/share/nvim/site/pack/ci/opt
+ln -s "$(pwd)" ~/.local/share/nvim/site/pack/ci/opt


### PR DESCRIPTION
Adapts the linter to use the query parser in the nvim-treesitter repo, rather than the bundled Neovim one. This prevents breaking parser changes from messing up the formatting lint.

See https://github.com/nvim-treesitter/nvim-treesitter/commit/d3acd105bd48b6529cb5dc02e73d96990862e196