### PR TITLE
fix(odin): update `has-type` renamed to `kind-eq`

### DIFF
--- a/queries/odin/textobjects.scm
+++ b/queries/odin/textobjects.scm
@@ -22,7 +22,7 @@
 ; plain call
 ((_
   (call_expression) @call.outer) @_parent
-  (#not-has-type? @_parent "member_expression"))
+  (#not-kind-eq? @_parent "member_expression"))
 
 ; call arguments
 ((call_expression


### PR DESCRIPTION
Treesitter predicate changed upstream to align with Helix: https://github.com/nvim-treesitter/nvim-treesitter/commit/a80fe081b4c5890980561e0de2458f64aaffbfc7