### PR TITLE
fix: include_surrouding_whitespaces

### DIFF
--- a/lua/nvim-treesitter-textobjects/select.lua
+++ b/lua/nvim-treesitter-textobjects/select.lua
@@ -116,7 +116,8 @@ local function include_surrounding_whitespace(bufnr, range, selection_mode)
   end
   if extended then
     -- don't extend in both directions
-    return { start_row, start_col, end_row, end_col }
+    range:set_range4 { start_row, start_col, end_row, end_col }
+    return range
   end
   local next_row, next_col = next_position(bufnr, start_row, start_col, false)
 

--- a/lua/nvim-treesitter-textobjects/shared.lua
+++ b/lua/nvim-treesitter-textobjects/shared.lua
@@ -513,10 +513,10 @@ function M.Range:set_range4(range4)
   if self.metadata and self.metadata.range then
     self.metadata.range = range4
   end
-  self.start_col = range4[1]
-  self.start_row = range4[2]
-  self.end_col = range4[3]
-  self.end_row = range4[4]
+  self.start_row = range4[1]
+  self.start_col = range4[2]
+  self.end_row = range4[3]
+  self.end_col = range4[4]
 end
 
 ---@return lsp.Range


### PR DESCRIPTION
Two bugs in the code cause the select feature to be totally unusable after `include_surrouding_whitespaces` is enabled.