### PR TITLE
feat(c_sharp): add class.outer support for records, enums, interfaces

### DIFF
--- a/queries/c_sharp/textobjects.scm
+++ b/queries/c_sharp/textobjects.scm
@@ -9,6 +9,14 @@
     "}"
     (#make-range! "class.inner" @_start @_end))) @class.outer
 
+(class_declaration
+  body: (declaration_list
+    .
+    "{"
+    .
+    "}"
+    )) @class.outer
+
 (struct_declaration
   body: (declaration_list
     .
@@ -19,6 +27,71 @@
     .
     "}"
     (#make-range! "class.inner" @_start @_end))) @class.outer
+
+(struct_declaration
+  body: (declaration_list
+    .
+    "{"
+    .
+    "}"
+    )) @class.outer
+
+(record_declaration
+  body: (declaration_list
+    .
+    "{"
+    .
+    (_) @_start @_end
+    (_)? @_end
+    .
+    "}"
+    (#make-range! "class.inner" @_start @_end))) @class.outer
+
+(record_declaration
+  body: (declaration_list
+    .
+    "{"
+    .
+    "}"
+    )?) @class.outer
+
+(interface_declaration
+  body: (declaration_list
+    .
+    "{"
+    .
+    (_) @_start @_end
+    (_)? @_end
+    .
+    "}"
+    (#make-range! "class.inner" @_start @_end))) @class.outer
+
+(interface_declaration
+  body: (declaration_list
+    .
+    "{"
+    .
+    "}"
+    )) @class.outer
+
+(enum_declaration
+  body: (enum_member_declaration_list
+    .
+    "{"
+    .
+    (_) @_start @_end
+    (_)? @_end
+    .
+    "}"
+    (#make-range! "class.inner" @_start @_end))) @class.outer
+
+(enum_declaration
+  body: (enum_member_declaration_list
+    .
+    "{"
+    .
+    "}"
+    )) @class.outer
 
 (method_declaration
   body: (block


### PR DESCRIPTION
Extends support for recognizing class.outer for the following types:

- classes with empty declarations

```cs
public class MyClass {}
```

- structs with empty declarations

```cs
public struct MyStruct {}
```

- records

```cs
public record MyRecord1();
public record MyRecord2() {}
public record MyRecord3 {}
```

- interfaces

```cs
public IMyInterface {}
```

- enums

```cs
public enum MyEnum {}
```

Before these changes, only structs and classes (both needed to have at least 1 member) had been supported.

Note: Ideally, there should also be support for structs, interfaces, classes and enums without curly braces (e.g. `class MyClass;` or `class MyClass();`), but it seems that tree-sitter does not support that syntax yet, tree inspection shows errors.