### PR TITLE
fix: handle nil start_nodes for `query_predicates`.

### DIFF
--- a/plugin/query_predicates.lua
+++ b/plugin/query_predicates.lua
@@ -10,7 +10,9 @@ ts.query.add_directive("make-range!", function(match, pattern, buf, predicate, m
   local start_nodes = match[start_node_id]
   local end_nodes = match[end_node_id]
 
-  assert(#start_nodes == 1, "#make-range! does not support captures on multiple nodes")
+  if start_nodes then
+    assert(#start_nodes == 1, "#make-range! does not support captures on multiple nodes")
+  end
   if end_nodes then
     assert(#end_nodes == 1, "#make-range! does not support captures on multiple nodes")
   end


### PR DESCRIPTION
This PR attempts to fix the following error when using text objects in R source file. The following is an example of R file:

```r
hello <- function()
    |print('hello')
}

```

Where `|` is the cursor position.


The following is an example of nvim config

```lua
 vim.keymap.set({ 'x', 'o' }, 'af', function()
        require('nvim-treesitter-textobjects.select').select_textobject('@function.outer', 'textobjects')
 end)
```

pressing `af` at the cursor position will lead to the following error:

```lua
E5108: Error executing lua: .../nvim-treesitter-textobjects/plugin/query_predicates.lua:13: attempt to get length of local 'start_nodes' (a nil value)          
stack traceback:                                                                                                                                                
        .../nvim-treesitter-textobjects/plugin/query_predicates.lua:13: in function 'handler'                                                                   
        ...m/0.10.1/share/nvim/runtime/lua/vim/treesitter/query.lua:800: in function 'apply_directives'                                                         
        ...m/0.10.1/share/nvim/runtime/lua/vim/treesitter/query.lua:968: in function 'matches'                                                                  
        ...r-textobjects/lua/nvim-treesitter-textobjects/shared.lua:44: in function '(for generator)'                                                           
        ...r-textobjects/lua/nvim-treesitter-textobjects/shared.lua:145: in function 'fn'                                                                       
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:491: in function 'for_each_tree'                                                            
        ...r-textobjects/lua/nvim-treesitter-textobjects/shared.lua:142: in function 'get_capture_ranges_recursively'                                           
        ...r-textobjects/lua/nvim-treesitter-textobjects/shared.lua:377: in function 'textobject_at_point'                                                      
        ...r-textobjects/lua/nvim-treesitter-textobjects/select.lua:186: in function 'select_textobject'                                                        
        /Users/northyear/.config/nvim/lua/plugins/treesitter.lua:189: in function </Users/northyear/.config/nvim/lua/plugins/treesitter.lua:188> 
```