### PR TITLE
fix: avoid pass nonexistent field

### DIFF
--- a/lua/nvim-treesitter-textobjects/move.lua
+++ b/lua/nvim-treesitter-textobjects/move.lua
@@ -154,7 +154,7 @@ local function move(opts)
         end
       end
     end
-    goto_node(best_range and best_range.range, not best_start, not config.set_jumps)
+    goto_node(best_range, not best_start, not config.set_jumps)
   end
 end
 


### PR DESCRIPTION
This line tries to access `range` on `TSTextObjects.Range`, which does not have this field, so the passed value will be `nil`. This bug makes the `move` feature usable.