### PR TITLE
Some fixes for types

### DIFF
--- a/lua/nvim-treesitter-textobjects/move.lua
+++ b/lua/nvim-treesitter-textobjects/move.lua
@@ -16,7 +16,7 @@ local function goto_node(range, goto_end, avoid_set_jump)
   if not avoid_set_jump then
     shared.set_jump()
   end
-  local vim_range = { range:to_vim_range() } ---@type Range4
+  local vim_range = range:to_vim_range()
   ---@type table<number>
   local position
   if not goto_end then

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -15,7 +15,7 @@
 local M = {}
 
 ---@class TSTextObjects.RepeatableMove
----@field func function
+---@field func string | function
 ---@field opts table
 ---@field additional_args table
 

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -105,7 +105,7 @@ M.make_repeatable_move_pair = function(forward_move_fn, backward_move_fn)
   return repeatable_forward_move_fn, repeatable_backward_move_fn
 end
 
----@param opts_extend table
+---@param opts_extend table?
 ---@return boolean
 M.repeat_last_move = function(opts_extend)
   if M.last_move then

--- a/lua/nvim-treesitter-textobjects/select.lua
+++ b/lua/nvim-treesitter-textobjects/select.lua
@@ -5,7 +5,8 @@ local shared = require "nvim-treesitter-textobjects.shared"
 ---@param range TSTextObjects.Range
 ---@param selection_mode string
 local function update_selection(range, selection_mode)
-  local start_row, start_col, end_row, end_col = range:to_vim_range()
+  ---@type integer, integer, integer, integer
+  local start_row, start_col, end_row, end_col = unpack(range:to_vim_range())
 
   local v_table = { charwise = "v", linewise = "V", blockwise = "<C-v>" }
   selection_mode = selection_mode or "charwise"

--- a/lua/nvim-treesitter-textobjects/shared.lua
+++ b/lua/nvim-treesitter-textobjects/shared.lua
@@ -533,7 +533,7 @@ function M.Range:to_lsp_range()
   }
 end
 
----@return integer, integer, integer, integer
+---@return Range4
 function M.Range:to_vim_range()
   local srow, scol, erow, ecol = unpack(self:range4()) ---@type integer, integer, integer, integer
   srow = srow + 1
@@ -550,7 +550,7 @@ function M.Range:to_vim_range()
     end
     ecol = math.max(ecol, 1)
   end
-  return srow, scol, erow, ecol
+  return { srow, scol, erow, ecol }
 end
 
 ---@return string[]


### PR DESCRIPTION
The first two are easy to understand, for the third one, LuaLS could not match a return type of `integer, integer, integer, integer` to `{ [1]: integer, [2]: integer, [3]: integer, [4], integer }` when it was packed. Obviously, the original author noticed that so they provided `unpack4` for that. This makes the code more consistent and removes the wrong diagnostic error.