### PR TITLE
fix(repeatable_move): remove deprecated and unused functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,22 +200,7 @@ vim.keymap.set({ "n", "x", "o" }, "<end>", function()
 end)
 ```
 
-Furthermore, you can make any custom movements (e.g. from another plugin) repeatable with the same keys.
-This doesn't need to be treesitter-related.
-
-```lua
--- example: make gitsigns.nvim movement repeatable with ; and , keys.
-local gs = require("gitsigns")
-
--- make sure forward function comes first
-local next_hunk_repeat, prev_hunk_repeat = ts_repeat_move.make_repeatable_move_pair(gs.next_hunk, gs.prev_hunk)
--- Or, use `make_repeatable_move` or `set_last_move` functions for more control. See the code for instructions.
-
-vim.keymap.set({ "n", "x", "o" }, "]h", next_hunk_repeat)
-vim.keymap.set({ "n", "x", "o" }, "[h", prev_hunk_repeat)
-```
-
-Alternatively, you could use a repeatable movement managing plugin such as [nvim-next](https://github.com/ghostbuster91/nvim-next).
+For a similar way of making arbitrary movements repeatable, see [nvim-next](https://github.com/ghostbuster91/nvim-next).
 
 # Overriding or extending textobjects
 

--- a/lua/nvim-treesitter-textobjects/move.lua
+++ b/lua/nvim-treesitter-textobjects/move.lua
@@ -38,13 +38,6 @@ end
 
 local M = {}
 
----@class TSTextObjects.MoveOpts
----@field query_strings_regex string[]|string
----@field query_group? string
----@field forward boolean
----@field start? boolean If true, choose the start of the node, and false is for the end.
----@field winid? integer
-
 ---@param opts TSTextObjects.MoveOpts
 local function move(opts)
   local query_group = opts.query_group or "textobjects"

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -12,10 +12,6 @@ local M = {}
 -- prefer to set using M.set_last_move
 M.last_move = nil
 
-M.clear_last_move = function()
-  M.last_move = nil
-end
-
 --- move_fn's first argument must be a table of options, and it should include a `forward` boolean
 --- indicating whether to move forward (true) or backward (false)
 ---
@@ -23,7 +19,7 @@ end
 ---@param opts table
 ---@param ... any
 ---@return boolean
-M.set_last_move = function(move_fn, opts, ...)
+local set_last_move = function(move_fn, opts, ...)
   if type(move_fn) ~= "function" then
     vim.notify(
       "nvim-treesitter-textobjects: move_fn has to be a function but got " .. vim.inspect(move_fn),
@@ -57,38 +53,9 @@ end
 ---@return fun(opts: table, ...: any)
 M.make_repeatable_move = function(move_fn)
   return function(opts, ...)
-    M.set_last_move(move_fn, opts, ...)
+    set_last_move(move_fn, opts, ...)
     move_fn(opts, ...)
   end
-end
-
--- Alternative:
--- Get a movement function pair (forward, backward) and turn them into two repeatable movement functions
--- They don't need to have the first argument as a table of options
----@param forward_move_fn function
----@param backward_move_fn function
----@return fun(...: any) repeatable_forward_move_fn
----@return fun(...: any) repeatable_backward_move_fn
-M.make_repeatable_move_pair = function(forward_move_fn, backward_move_fn)
-  local general_repeatable_move_fn = function(opts, ...)
-    if opts.forward then
-      forward_move_fn(...)
-    else
-      backward_move_fn(...)
-    end
-  end
-
-  local repeatable_forward_move_fn = function(...)
-    M.set_last_move(general_repeatable_move_fn, { forward = true }, ...)
-    forward_move_fn(...)
-  end
-
-  local repeatable_backward_move_fn = function(...)
-    M.set_last_move(general_repeatable_move_fn, { forward = false }, ...)
-    backward_move_fn(...)
-  end
-
-  return repeatable_forward_move_fn, repeatable_backward_move_fn
 end
 
 ---@param opts_extend table?

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -1,17 +1,3 @@
--- If you are a plugin developer (or just want to make other movement plugins repeatable),
--- you can register your own independent move functions
--- even if they are not related to treesitter-textobjects.
--- Use one of the followings:
---   M.make_repeatable_move(move_fn)
---   M.make_repeatable_move_pair(forward_move_fn, backward_move_fn)
---   M.set_last_move(move_fn, opts, ...)
---
--- Then you can use four functions to repeat the last movement:
---   M.repeat_last_move
---   M.repeat_last_move_opposite
---   M.repeat_last_move_next
---   M.repeat_last_move_previous
-
 local M = {}
 
 ---@class TSTextObjects.RepeatableMove
@@ -126,15 +112,15 @@ M.repeat_last_move = function(opts_extend)
 
     if M.last_move.func == "f" or M.last_move.func == "t" then
       if opts.forward then
-        vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
+        vim.cmd.normal { args = { vim.v.count1, ";" }, bang = true }
       else
-        vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
+        vim.cmd.normal { args = { vim.v.count1, "," }, bang = true }
       end
     elseif M.last_move.func == "F" or M.last_move.func == "T" then
       if opts.forward then
-        vim.cmd([[normal! ]] .. vim.v.count1 .. ",")
+        vim.cmd.normal { args = { vim.v.count1, "," }, bang = true }
       else
-        vim.cmd([[normal! ]] .. vim.v.count1 .. ";")
+        vim.cmd.normal { args = { vim.v.count1, ";" }, bang = true }
       end
     else
       M.last_move.func(opts, unpack(M.last_move.additional_args))
@@ -195,143 +181,6 @@ M.builtin_T_expr = function()
     additional_args = {},
   }
   return "T"
-end
-
----@class TSTextObjects.BuiltinFindOpts
----@field forward boolean forward = true -> f, t
----@field inclusive boolean inclusive = false -> t, T
----@field char? string
----@field repeating? boolean if repeating with till (t or T, inclusive = false) then search from the next character
----@field winid? integer
-
--- implements naive f, F, t, T with repeat support
----@deprecated
----@param opts TSTextObjects.BuiltinFindOpts
----@return string? char
-local function builtin_find(opts)
-  local forward = opts.forward
-  local inclusive = opts.inclusive
-  local char = opts.char or vim.fn.nr2char(vim.fn.getchar())
-  local repeating = opts.repeating or false
-  local winid = opts.winid or vim.api.nvim_get_current_win()
-
-  if char == vim.fn.nr2char(27) then
-    -- escape
-    return nil
-  end
-
-  local line = vim.api.nvim_get_current_line()
-  local cursor = vim.api.nvim_win_get_cursor(winid)
-
-  -- count works like this with builtin vim motions.
-  -- weird, but we're matching the behaviour
-  local count ---@type integer
-  if not inclusive and repeating then
-    count = math.max(vim.v.count1 - 1, 1)
-  else
-    count = vim.v.count1
-  end
-
-  -- find the count-th occurrence of the char in the line
-  local found ---@type integer?
-  for _ = 1, count do
-    if forward then
-      if not inclusive and repeating then
-        cursor[2] = cursor[2] + 1
-      end
-      found = line:find(char, cursor[2] + 2, true)
-    else
-      -- reverse find from the cursor position
-      if not inclusive and repeating then
-        cursor[2] = cursor[2] - 1
-      end
-
-      found = line:reverse():find(char, #line - cursor[2] + 1, true)
-      if found then
-        found = #line - found + 1
-      end
-    end
-
-    if not found then
-      return char
-    end
-
-    if forward then
-      if not inclusive then
-        found = found - 1
-      end
-    else
-      if not inclusive then
-        found = found + 1
-      end
-    end
-
-    cursor[2] = found - 1
-    repeating = true -- after the first iteration, search from the next character if not inclusive.
-  end
-
-  -- Enter visual mode if we are in operator-pending mode
-  -- If we don't do this, it will miss the last character.
-  local mode = vim.api.nvim_get_mode()
-  if mode.mode == "no" then
-    vim.cmd "normal! v"
-  end
-
-  -- move to the found position
-  vim.api.nvim_win_set_cursor(winid, { cursor[1], cursor[2] })
-  return char
-end
-
--- We are not using M.make_repeatable_move and instead registering at M.last_move manually
--- because we don't want to behave the same way as the first movement.
--- For example, we want to repeat the search character given to f, F, t, T.
--- Also, we want to be able to to find the next occurence when using t, T with repeat, excluding the current position.
----@deprecated
-M.builtin_f = function()
-  vim.notify_once("nvim-treesitter-textobjects: map `builtin_f_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
-  local opts = { forward = true, inclusive = true }
-  local char = builtin_find(opts)
-  if char ~= nil then
-    opts.char = char
-    opts.repeating = true
-    M.set_last_move(builtin_find, opts)
-  end
-end
-
----@deprecated
-M.builtin_F = function()
-  vim.notify_once("nvim-treesitter-textobjects: map `builtin_F_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
-  local opts = { forward = false, inclusive = true }
-  local char = builtin_find(opts)
-  if char ~= nil then
-    opts.char = char
-    opts.repeating = true
-    M.set_last_move(builtin_find, opts)
-  end
-end
-
----@deprecated
-M.builtin_t = function()
-  vim.notify_once("nvim-treesitter-textobjects: map `builtin_t_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
-  local opts = { forward = true, inclusive = false }
-  local char = builtin_find(opts)
-  if char ~= nil then
-    opts.char = char
-    opts.repeating = true
-    M.set_last_move(builtin_find, opts)
-  end
-end
-
----@deprecated
-M.builtin_T = function()
-  vim.notify_once("nvim-treesitter-textobjects: map `builtin_T_expr` with `{expr=true}` instead.", vim.log.levels.WARN)
-  local opts = { forward = false, inclusive = false }
-  local char = builtin_find(opts)
-  if char ~= nil then
-    opts.char = char
-    opts.repeating = true
-    M.set_last_move(builtin_find, opts)
-  end
 end
 
 return M


### PR DESCRIPTION
Also stop advertising as generic API and point to nvim-next instead.
