### PR TITLE
fix(zig): exclude braces in function.inner

### DIFF
--- a/queries/zig/textobjects.scm
+++ b/queries/zig/textobjects.scm
@@ -7,7 +7,15 @@
 ; functions
 (_
   (FnProto)
-  (Block) @function.inner) @function.outer
+  ((Block
+    .
+    "{"
+    .
+    (_) @_start @_end
+    (_)? @_end
+    .
+    "}")
+    (#make-range! "function.inner" @_start @_end))) @function.outer
 
 ; loops
 (_


### PR DESCRIPTION
Fixes #669 