### PR TITLE
refactor(repeatable_move): extract the `MoveFunction` interface

### DIFF
--- a/lua/nvim-treesitter-textobjects/move.lua
+++ b/lua/nvim-treesitter-textobjects/move.lua
@@ -36,11 +36,13 @@ end
 local M = {}
 
 ---@param opts TSTextObjects.MoveOpts
-local function move(opts)
-  local query_group = opts.query_group or "textobjects"
-  local query_strings = type(opts.query_strings) == "string" and { opts.query_strings } or opts.query_strings
+---@param query_strings string[]|string
+---@param query_group? string
+local function move(opts, query_strings, query_group)
+  query_group = query_group or "textobjects"
+  query_strings = type(query_strings) == "string" and { query_strings } or query_strings
 
-  local winid = opts.winid or api.nvim_get_current_win()
+  local winid = api.nvim_get_current_win()
   local bufnr = api.nvim_win_get_buf(winid)
 
   local forward = opts.forward
@@ -132,67 +134,57 @@ local function move(opts)
   end
 end
 
----@type fun(opts: TSTextObjects.MoveOpts)
+---@type fun(opts: TSTextObjects.MoveOpts, query_strings: string[]|string, query_group?: string)
 local move_repeatable = repeatable_move.make_repeatable_move(move)
 
 ---@param query_strings string|string[]
 ---@param query_group? string
 M.goto_next_start = function(query_strings, query_group)
-  move_repeatable {
+  move_repeatable({
     forward = true,
     start = true,
-    query_strings = query_strings,
-    query_group = query_group,
-  }
+  }, query_strings, query_group)
 end
 ---@param query_strings string|string[]
 ---@param query_group? string
 M.goto_next_end = function(query_strings, query_group)
-  move_repeatable {
+  move_repeatable({
     forward = true,
     start = false,
-    query_strings = query_strings,
-    query_group = query_group,
-  }
+  }, query_strings, query_group)
 end
 ---@param query_strings string|string[]
 ---@param query_group? string
 M.goto_previous_start = function(query_strings, query_group)
-  move_repeatable {
+  move_repeatable({
     forward = false,
     start = true,
-    query_strings = query_strings,
-    query_group = query_group,
-  }
+  }, query_strings, query_group)
 end
 ---@param query_strings string|string[]
 ---@param query_group? string
 M.goto_previous_end = function(query_strings, query_group)
-  move_repeatable {
+  move_repeatable({
     forward = false,
     start = false,
-    query_strings = query_strings,
-    query_group = query_group,
-  }
+  }, query_strings, query_group)
 end
 
 ---@param query_strings string|string[]
 ---@param query_group? string
 M.goto_next = function(query_strings, query_group)
-  move_repeatable {
+  move_repeatable({
     forward = true,
-    query_strings = query_strings,
-    query_group = query_group,
-  }
+  }, query_strings, query_group)
 end
 ---@param query_strings string|string[]
 ---@param query_group? string
 M.goto_previous = function(query_strings, query_group)
-  move_repeatable {
+  move_repeatable({
     forward = false,
     query_strings = query_strings,
     query_group = query_group,
-  }
+  }, query_strings, query_group)
 end
 
 return M

--- a/lua/nvim-treesitter-textobjects/move.lua
+++ b/lua/nvim-treesitter-textobjects/move.lua
@@ -40,7 +40,9 @@ local M = {}
 ---@param query_group? string
 local function move(opts, query_strings, query_group)
   query_group = query_group or "textobjects"
-  query_strings = type(query_strings) == "string" and { query_strings } or query_strings
+  if type(query_strings) == "string" then
+    query_strings = { query_strings }
+  end
 
   local winid = api.nvim_get_current_win()
   local bufnr = api.nvim_win_get_buf(winid)

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -1,11 +1,8 @@
 local M = {}
 
 ---@class TSTextObjects.MoveOpts
----@field query_strings? string[]|string
----@field query_group? string
----@field forward boolean
+---@field forward boolean If true, move forward, and false is for backward.
 ---@field start? boolean If true, choose the start of the node, and false is for the end.
----@field winid? integer
 
 ---@class TSTextObjects.RepeatableMove
 ---@field func string | function

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -4,8 +4,10 @@ local M = {}
 ---@field forward boolean If true, move forward, and false is for backward.
 ---@field start? boolean If true, choose the start of the node, and false is for the end.
 
+---@alias TSTextObjects.MoveFunction fun(opts: TSTextObjects.MoveOpts, ...: any)
+
 ---@class TSTextObjects.RepeatableMove
----@field func string | function
+---@field func string | TSTextObjects.MoveFunction
 ---@field opts TSTextObjects.MoveOpts
 ---@field additional_args table
 
@@ -15,8 +17,8 @@ M.last_move = nil
 --- Make move function repeatable. Creates a wrapper that takes a TSTextObjects.MoveOpts table,
 --- stores them, and executes the move.
 ---
----@param move_fn function
----@return fun(opts: TSTextObjects.MoveOpts, ...: any)
+---@param move_fn TSTextObjects.MoveFunction
+---@return TSTextObjects.MoveFunction
 M.make_repeatable_move = function(move_fn)
   return function(opts, ...)
     M.last_move = { func = move_fn, opts = vim.deepcopy(opts), additional_args = { ... } }

--- a/lua/nvim-treesitter-textobjects/swap.lua
+++ b/lua/nvim-treesitter-textobjects/swap.lua
@@ -154,11 +154,13 @@ end
 
 local M = {}
 
----@param captures string|string[]
+---@param query_strings string|string[]
 ---@param query_group? string
 ---@param direction integer
-local function swap_textobject(captures, query_group, direction)
-  local query_strings = type(captures) == "string" and { captures } or captures
+local function swap_textobject(query_strings, query_group, direction)
+  if type(query_strings) == "string" then
+    query_strings = { query_strings }
+  end
   query_group = query_group or "textobjects"
   local bufnr = vim.api.nvim_get_current_buf()
 


### PR DESCRIPTION
`repeatable_move` is out of the plugin's scope, and I agree with simplifying it. But even if the `make_repeatable_move_pair` was removed, the current API is good enough for users to define their repeatable move, it only needs some refactoring and documentation. Also contains some tiny improvements for type annotations.

`nvim-next` does not support the `main` branch, so there's no replacement for users now, but since its author knows this so it might be implemented in the future, so I kept the reference to `nvim-next`. see https://github.com/ghostbuster91/nvim-next/issues/22.

Edit:
I changed this PR to `feat` because the `MoveFunction` interface should be guaranteed.