### PR TITLE
fix(php): Update syntax for anonymous functions

### DIFF
--- a/queries/php/textobjects.scm
+++ b/queries/php/textobjects.scm
@@ -12,7 +12,7 @@
 
 (function_definition) @function.outer
 
-(anonymous_function_creation_expression
+(anonymous_function
   body: (compound_statement
     .
     "{"
@@ -23,7 +23,7 @@
     "}"
     (#make-range! "function.inner" @_start @_end)))
 
-(anonymous_function_creation_expression) @function.outer
+(anonymous_function) @function.outer
 
 ; methods
 (method_declaration


### PR DESCRIPTION
- Renamed `anonymous_function_creation_expression` to `anonymous_function` to align with the upstream change in tree-sitter-php (see tree-sitter/tree-sitter-php#247).