### PR TITLE
feat: modify behaviour of `@assignment.outer` so it includes keywords like `const`, `local` etc. and semicolon

### DIFF
--- a/queries/apex/textobjects.scm
+++ b/queries/apex/textobjects.scm
@@ -99,6 +99,12 @@
 ] @comment.outer
 
 ; assignment
-(variable_declarator
-  name: (identifier) @assignment.lhs
-  value: (_) @assignment.rhs) @assignment.inner @assignment.outer
+(field_declaration
+  (variable_declarator
+    name: (identifier) @assignment.lhs
+    value: (_) @assignment.rhs) @assignment.inner) @assignment.outer
+
+(local_variable_declaration
+  (variable_declarator
+    name: (identifier) @assignment.lhs
+    value: (_) @assignment.rhs) @assignment.inner) @assignment.outer

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -239,9 +239,10 @@
 ; number
 (number) @number.inner
 
-(variable_declarator
-  name: (_) @assignment.lhs
-  value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+(lexical_declaration
+  (variable_declarator
+    name: (_) @assignment.lhs
+    value: (_) @assignment.inner @assignment.rhs)) @assignment.outer
 
 (variable_declarator
   name: (_) @assignment.inner)

--- a/queries/go/textobjects.scm
+++ b/queries/go/textobjects.scm
@@ -157,18 +157,22 @@
   left: (_) @assignment.lhs
   right: (_) @assignment.rhs @assignment.inner) @assignment.outer
 
-(var_spec
-  name: (_) @assignment.lhs
-  value: (_) @assignment.rhs @assignment.inner) @assignment.outer
+(var_declaration
+  (var_spec
+    name: (_) @assignment.lhs
+    value: (_) @assignment.rhs @assignment.inner)) @assignment.outer
 
-(var_spec
-  name: (_) @assignment.inner
-  type: (_)) @assignment.outer
+(var_declaration
+  (var_spec
+    name: (_) @assignment.inner
+    type: (_))) @assignment.outer
 
-(const_spec
-  name: (_) @assignment.lhs
-  value: (_) @assignment.rhs @assignment.inner) @assignment.outer
+(const_declaration
+  (const_spec
+    name: (_) @assignment.lhs
+    value: (_) @assignment.rhs @assignment.inner)) @assignment.outer
 
-(const_spec
-  name: (_) @assignment.inner
-  type: (_)) @assignment.outer
+(const_declaration
+  (const_spec
+    name: (_) @assignment.inner
+    type: (_))) @assignment.outer

--- a/queries/julia/textobjects.scm
+++ b/queries/julia/textobjects.scm
@@ -217,10 +217,23 @@
   (#make-range! "parameter.outer" @parameter.inner @_end))
 
 ; Assignment
-(assignment
-  .
-  (_) @assignment.lhs
-  (_) @assignment.inner @assignment.rhs .) @assignment.outer
+(local_statement
+  (assignment
+    .
+    (_) @assignment.lhs
+    (_) @assignment.inner @assignment.rhs .)) @assignment.outer
+
+(const_statement
+  (assignment
+    .
+    (_) @assignment.lhs
+    (_) @assignment.inner @assignment.rhs .)) @assignment.outer
+
+(global_statement
+  (assignment
+    .
+    (_) @assignment.lhs
+    (_) @assignment.inner @assignment.rhs .)) @assignment.outer
 
 (assignment
   .

--- a/queries/lua/textobjects.scm
+++ b/queries/lua/textobjects.scm
@@ -103,9 +103,10 @@
 ; number
 (number) @number.inner
 
-(assignment_statement
-  (variable_list) @assignment.lhs
-  (expression_list) @assignment.inner @assignment.rhs) @assignment.outer
+(variable_declaration
+  (assignment_statement
+    (variable_list) @assignment.lhs
+    (expression_list) @assignment.inner @assignment.rhs)) @assignment.outer
 
 (assignment_statement
   (variable_list) @assignment.inner)


### PR DESCRIPTION
Goal of PR (For all languages which support either of the first 1-4 text objects): 

- Change `assignment.outer` so that it captures extra tokens like `const` and semicolon

### Examples

### ecma (js, jsx, ts, tsx):

```ts
const x = 5;
```
- `@assignment.outer`: `const x = 5;`

### c and c++

```c
int x = 5;
```
- `@assignment.outer`: `int x = 5;`

### bash

```bash
x=5
```

- `@assignment.outer`: `x=5`

### python

```python
x = 5
```

- `@assignment.outer`: `x=5`

### css and scss:
```css
body {
  margin: 1px 2px 3px 4px;
}
```

- `@assignment.outer`: `margin: 1px 2px 3px 4px;`

### Languages changed:

a -> b, c means b and c inherit from a, so no changes were made to b or c

- [x] apex 
- [x] go
- [x] ecma -> js, ts, jsx, tsx, 
- [x] lua
- [x] julia
 
### Languages not changed since they don't have keywords like `const` or similar, OR they were already working well:

- [x] nim
- [x] python
- [x] bash
- [x] yaml
- [x] rust 
- [x] cuda 
- [x] fish
- [x] css -> sass
- [x] hcl -> terraform
- [x] c -> fennel, ( cpp -> glsl, ( hlsl -> slang ) )
- [x] inko
- [x] matlab
- [x] odin
- [x] r
- [x] tact
- [x] v
- [x] vim

Closes #681 