### PR TITLE
fix: Adjust selected range when `set selection=exclusive`

### DIFF
--- a/lua/nvim-treesitter-textobjects/select.lua
+++ b/lua/nvim-treesitter-textobjects/select.lua
@@ -27,10 +27,16 @@ local function update_selection(range, selection_mode)
     vim.cmd.normal { selection_mode, bang = true }
   end
 
+  local end_col_offset = 1
+
+  if selection_mode == "v" and vim.o.selection == "exclusive" then
+    end_col_offset = 0
+  end
+
   -- Position is 1, 0 indexed.
   api.nvim_win_set_cursor(0, { start_row + 1, start_col })
   vim.cmd "normal! o"
-  api.nvim_win_set_cursor(0, { end_row + 1, end_col - 1 })
+  api.nvim_win_set_cursor(0, { end_row + 1, end_col - end_col_offset })
 end
 
 local M = {}


### PR DESCRIPTION
Fixes #488

When the user has `set selection=exclusive` the selection was one character short. This PR addresses that.

Note that this PR fixes it in the `main` branch. The `master` branch uses a function [outside of this repo](https://github.com/afgomez/nvim-treesitter-textobjects/blob/bf8d2ad35d1d1a687eae6c065c3d524f7ab61b23/lua/nvim-treesitter/textobjects/select.lua#L114), so it cannot be fixed here.

