### PR TITLE
feat: cache textobjects created from a ts query

### DIFF
--- a/lua/nvim-treesitter/textobjects/shared.lua
+++ b/lua/nvim-treesitter/textobjects/shared.lua
@@ -93,9 +93,14 @@ function M.get_query_strings_from_regex(query_strings_regex, query_group, lang)
   return query_strings
 end
 
+local textobjects_cache = {}
 function M.available_textobjects(lang, query_group)
   lang = lang or parsers.get_buf_lang()
   query_group = query_group or "textobjects"
+  if textobjects_cache[lang] and textobjects_cache[lang][query_group] then
+    return textobjects_cache[lang][query_group]
+  end
+  textobjects_cache[lang] = textobjects_cache[lang] or {}
   local parsed_queries = ts.get_query(lang, query_group)
   if not parsed_queries then
     return {}
@@ -109,6 +114,7 @@ function M.available_textobjects(lang, query_group)
       end
     end
   end
+  textobjects_cache[lang][query_group] = found_textobjects
   return found_textobjects
   --patterns = {
   --[2] = { { "make-range!", "function.inner", 2, 3 } },


### PR DESCRIPTION
### Problem

When the user opens a file with this plugin installed (most notably latex, dart, zig and rust files), a slow [ts.get_query](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/bf8d2ad35d1d1a687eae6c065c3d524f7ab61b23/lua/nvim-treesitter/textobjects/shared.lua#L99) will get called, that can take 3500ms for a latex file on an older machine. The reason for this is tree-sitter is trying to do some [aggressive initial analysis](https://github.com/tree-sitter/tree-sitter/issues/973#issuecomment-2182951245) of the query (eg. [latex/textobjects.scm](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/bf8d2ad35d1d1a687eae6c065c3d524f7ab61b23/queries/latex/textobjects.scm)).

Neovim acknowledged that this function call is slow and [memoized](https://github.com/neovim/neovim/blob/78b85109338592c2bc89154278f2e961a14eee96/runtime/lua/vim/treesitter/query.lua#L216) it, however it doesn't get cached for too long, as the cache gets [garbage collected](https://github.com/neovim/neovim/blob/78b85109338592c2bc89154278f2e961a14eee96/runtime/lua/vim/func.lua#L17-L18). For me this cache gets cleared after opening 2-3 files, so it's not that useful.

### This PR's solution

This PR puts computed queries in a cache which lives as long as neovim is open.

### Further work

A proper upstream fix would be the best, but this performance issue is present for months and I don't see any progress on it.
In order to persist the cache between neovim sessions, we could store the cache somewhere in probably ~/.local/state/nvim. And for cache invalidation, we could also store the hash of the .scm files and invalidate the cache when the hash changes.

### Other issues and PRs

Helps a lot with #461, #627.
Upstream issue this PR is working around: https://github.com/tree-sitter/tree-sitter/issues/973.
In neovim a similar caching system was implemented in https://github.com/neovim/neovim/pull/24222, but got replaced with the garbage collected memoization in https://github.com/neovim/neovim/pull/25201.
Other plugins are resorting to this kind of workaround, for example [noice](https://github.com/folke/noice.nvim/blob/6c87c1d11c38180fb72bf8f45518a0a3e081afc1/lua/noice/text/treesitter.lua#L25).

