### PR TITLE
fix(repeatable_move)!: make `d;` work like the builtin behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ local ts_repeat_move = require "nvim-treesitter-textobjects.repeatable_move"
 
 -- Repeat movement with ; and ,
 -- ensure ; goes forward and , goes backward regardless of the last direction
-vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next)
-vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous)
+vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next, { expr = true })
+vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous, { expr = true })
 
 -- vim way: ; goes to the direction you were moving.
 -- vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -27,34 +27,19 @@ M.make_repeatable_move = function(move_fn)
 end
 
 ---@param opts_extend TSTextObjects.MoveOpts?
----@return boolean
+---@return string?
 M.repeat_last_move = function(opts_extend)
-  if M.last_move then
-    local opts ---@type table
-    if opts_extend ~= nil then
-      opts = vim.tbl_deep_extend("force", {}, M.last_move.opts, opts_extend)
-    else
-      opts = M.last_move.opts
-    end
-
-    if M.last_move.func == "f" or M.last_move.func == "t" then
-      if opts.forward then
-        vim.cmd.normal { vim.v.count1 .. ";", bang = true }
-      else
-        vim.cmd.normal { vim.v.count1 .. ",", bang = true }
-      end
-    elseif M.last_move.func == "F" or M.last_move.func == "T" then
-      if opts.forward then
-        vim.cmd.normal { vim.v.count1 .. ",", bang = true }
-      else
-        vim.cmd.normal { vim.v.count1 .. ";", bang = true }
-      end
-    else
-      M.last_move.func(opts, unpack(M.last_move.additional_args))
-    end
-    return true
+  if not M.last_move then
+    return
   end
-  return false
+  local opts = vim.tbl_deep_extend("force", M.last_move.opts, opts_extend or {})
+  if M.last_move.func == "f" or M.last_move.func == "t" then
+    return opts.forward and ";" or ","
+  elseif M.last_move.func == "F" or M.last_move.func == "T" then
+    return opts.forward and "," or ";"
+  else
+    return M.last_move.func(opts, unpack(M.last_move.additional_args))
+  end
 end
 
 M.repeat_last_move_opposite = function()

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -394,14 +394,14 @@ end)
 
 -- Repeat movement with ; and ,
 -- ensure ; goes forward and , goes backward regardless of the last direction
--- vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next)
--- vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous)
+-- vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next, { expr = true })
+-- vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous, { expr = true })
 
 local repeat_move = require "nvim-treesitter-textobjects.repeatable_move"
 
 -- vim way: ; goes to the direction you were moving.
-vim.keymap.set({ "n", "x", "o" }, ";", repeat_move.repeat_last_move)
-vim.keymap.set({ "n", "x", "o" }, ",", repeat_move.repeat_last_move_opposite)
+vim.keymap.set({ "n", "x", "o" }, ";", repeat_move.repeat_last_move, { expr = true })
+vim.keymap.set({ "n", "x", "o" }, ",", repeat_move.repeat_last_move_opposite, { expr = true })
 
 -- Optionally, make builtin f, F, t, T also repeatable with ; and ,
 vim.keymap.set({ "n", "x", "o" }, "f", repeat_move.builtin_f_expr, { expr = true })

--- a/tests/select/python_spec.lua
+++ b/tests/select/python_spec.lua
@@ -21,6 +21,8 @@ describe("command equality Python:", function()
   })
   -- select using built-in finds (f, F, t, T)
   run:compare_cmds("aligned_indent.py", { row = 1, col = 0, cmds = { "dfi", "vfid", "cfi" } })
+  -- repeatable move should work like default behavior (#699)
+  run:compare_cmds("aligned_indent.py", { row = 1, col = 0, cmds = { "dfn", "d;" } })
   -- select using move
   run:compare_cmds("aligned_indent.py", { row = 1, col = 0, cmds = { "d]a", "v]ad", "c]a" } })
   run:compare_cmds("selection_mode.py", { row = 2, col = 4, cmds = { "dam", "dVam", "vamd", "Vamd" } })


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/699
