### PR TITLE
fix(julia): query syntax error

### DIFF
--- a/queries/julia/textobjects.scm
+++ b/queries/julia/textobjects.scm
@@ -12,14 +12,14 @@
   .
   (_) @block.inner
   (_)? @block.inner .)
-)
+
 (let_statement) @block.outer
 
 (let_statement
   .
   (_) @block.inner
   (_)? @block.inner .)
-)
+
 ; Conditionals
 (if_statement
   condition: (_) @conditional.inner) @conditional.outer
@@ -49,7 +49,7 @@
   .
   (_) @conditional.inner
   (_)? @conditional.inner .)
-)
+
 ; Loops
 (for_statement) @loop.outer
 
@@ -75,7 +75,7 @@
   .
   (_) @class.inner
   (_)? @class.inner .)
-)
+
 ; Function definitions
 (function_definition) @function.outer
 


### PR DESCRIPTION
This is introduced by [aad2c8e6b029](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/commit/aad2c8e6b029ada30621e67780801420ee9debe9).