### PR TITLE
feat(gleam): support functions and parameters

### DIFF
--- a/queries/gleam/textobjects.scm
+++ b/queries/gleam/textobjects.scm
@@ -2,8 +2,8 @@
 (function
   body: (_) @function.inner) @function.outer
 
-(function_type
-  (_)) @function.outer
+(anonymous_function
+  body: (_) @function.inner) @function.outer
 
 ; parameter
 (function_parameters

--- a/queries/gleam/textobjects.scm
+++ b/queries/gleam/textobjects.scm
@@ -1,0 +1,25 @@
+; function
+(function
+  body: (_) @function.inner) @function.outer
+
+(function_type
+  (_)) @function.outer
+
+; parameter
+(function_parameters
+  (_) @parameter.inner
+  .
+  ","? @_end
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+(arguments
+  (_) @parameter.inner
+  .
+  ","? @_end
+  (#make-range! "parameter.outer" @parameter.inner @_end))
+
+(data_constructor_arguments
+  (_) @parameter.inner
+  .
+  ","? @_end
+  (#make-range! "parameter.outer" @parameter.inner @_end))


### PR DESCRIPTION
**functions**
```gleam
// @function.outer start
pub fn foo(a a: String, b b: String) -> String {
  // @function.inner start  
  a <> b
  // @function.inner end
}
// @function.outer end

// anonymous functions
//                   @function.outer start
with_callback("foo", fn () {
  // @function.inner start 
  "bar"
  // @function.inner end
} // @function.outer end
)
```

**parameters**
(NOTE: @parameter.outer includes trailing `,`)
```gleam
// function parameters
pub fn foo(a a: String, b b: String) -> String {
  a <> b
}

// arguments
foo(a: "foo", b: "bar")

// data constructor arguments
pub type Foo {
  Foo(a: String, b: String)
}
```