### PR TITLE
Update @statement.outer query for Ecma to also include lexical declarations

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -279,4 +279,5 @@
   (do_statement)
   (for_in_statement)
   (export_statement)
+  (lexical_declaration)
 ] @statement.outer


### PR DESCRIPTION
Added lexical declarations to @statement.outer capture group, e.g:
```
const a = 1;
```

should be selectable using @statement.outer capture group.