### PR TITLE
fix: offset_encoding is required now in `make_position_params`

### DIFF
--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -111,7 +111,11 @@ function M.peek_definition_code(query_string, query_group, lsp_request, context)
   if vim.tbl_contains(vim.api.nvim_list_wins(), floating_win) then
     vim.api.nvim_set_current_win(floating_win)
   else
-    local params = vim.lsp.util.make_position_params()
+    local win_id = vim.api.nvim_get_current_win()
+    local params = vim.fn.has "nvim-0.11" == 0 and vim.lsp.util.make_position_params()
+      or function(client)
+        return vim.api.util.make_position_params(win_id, client.offset_encoding)
+      end
     return vim.lsp.buf_request(
       0,
       lsp_request,


### PR DESCRIPTION
Adapt to the upstream change https://github.com/neovim/neovim/commit/629483e24eed3f2c07e55e0540c553361e0345a2 to get rid of the warning message "warning: offset_encoding is required, using the offset_encoding from the first client".

Since the commit https://github.com/neovim/neovim/commit/2dcbfe78fcec5f73ce061bb24b718187b9c6b134, `params` in `buf_request` can accept a function that takes the client as a parameter. So instead of sending the same params to all servers, the params with correct offset_encoding will send to each single server.