### PR TITLE
feat(ocaml): Add OCaml queries

### DIFF
--- a/queries/ocaml/textobjects.scm
+++ b/queries/ocaml/textobjects.scm
@@ -1,0 +1,57 @@
+(value_definition
+  (let_binding
+    body: (_) @function.inner)) @function.outer
+
+(method_definition
+  body: (_) @function.inner) @function.outer
+
+(class_definition
+  (class_binding
+    body: (_) @class.inner)) @class.outer
+
+(for_expression
+  (do_clause
+    (_) @loop.inner)) @loop.outer
+
+(while_expression
+  (do_clause
+    (_) @loop.inner)) @loop.outer
+
+(if_expression
+  condition: (_)
+  (then_clause
+    (_) @conditional.inner)
+  (else_clause
+    (_) @conditional.inner)) @conditional.outer
+
+(if_expression
+  condition: (_)
+  (then_clause
+    (_) @conditional.inner)) @conditional.outer
+
+(function_expression
+  (match_case) @_start @_end
+  (match_case)* @_end
+  (#make-range! "conditional.inner" @_start @_end)) @conditional.outer
+
+(match_expression
+  (match_case) @_start @_end
+  (match_case)* @_end
+  (#make-range! "conditional.inner" @_start @_end)) @conditional.outer
+
+(comment) @comment.outer
+
+(parameter) @parameter.outer
+
+(application_expression
+  argument: (_) @parameter.outer) @call.outer
+
+(application_expression
+  argument: (_) @_start @_end
+  argument: (_)* @_end
+  (#make-range! "call.inner" @_start @_end))
+
+(parenthesized_expression
+  (_) @_start @_end
+  (_)? @_end
+  (#make-range! "block.inner" @_start @_end)) @block.outer


### PR DESCRIPTION
I'm a treesitter queries newbie, so I'd appreciate the feedback on these queries.

This is an example of syntactically correct ocaml I used to test them:

```ocaml
let example_function param1 param2 = param1 + param2

class example_object =
  object (self)
    method do_stuff x = raise Not_found
  end

(* This is a comment. *)

let some_loops () =
  for variable = start_value to end_value do
    expression
  done;
  while boolean - condition do
    expression
  done

let conditionals () =
  let if_condition = if a then b else c in
  let match_cases = match a with b -> 1 | c -> 2 in
  let function_expression = function b -> 1 | c -> 2 in
  ()

let test_call =
  (* A function call, followed by 3 arguments. *)
  String.fold (fun a b -> a) 0 xs

let some_blocks =
  let begin_block = begin
    let inner_block = a in
    b
    end
  in
  let paren_block =
    (
      let inner_block = a in
      b
    )
  in c

```