### PR TITLE
feat(jsx): add jsx/tsx element captures

### DIFF
--- a/queries/jsx/textobjects.scm
+++ b/queries/jsx/textobjects.scm
@@ -3,3 +3,22 @@
 (jsx_attribute
   (property_identifier)
   (_) @parameter.inner) @parameter.outer
+
+; Self closing tags
+(jsx_self_closing_element
+  name: (identifier)
+  .
+  (_) @_start
+  (_)* @_end
+  .
+  (#make-range! "jsx_element.inner" @_start @_end)) @jsx_element.outer
+
+; Paired tags
+(jsx_element
+  open_tag: (_)
+  .
+  (_) @_start
+  (_)* @_end
+  .
+  close_tag: (_)
+  (#make-range! "jsx_element.inner" @_start @_end)) @jsx_element.outer


### PR DESCRIPTION
This PR adds `@jsx_element.inner`/`@jsx_element.outer` for jsx and tsx. Example usage:

- `dit`: turns `<Foo bar="bar" />` into `<Foo />`
- `dat`: turns `<Foo bar="bar" />` into ` ` (deletes the entire element)

With the following config:

```lua
vim.keymap.set({ "o", "x" }, "at", "<cmd>TSTextobjectSelect @jsx_element.outer<CR>") -- `t` for "tag"
vim.keymap.set({ "o", "x" }, "it", "<cmd>TSTextobjectSelect @jsx_element.inner<CR>")
```

This also works with jsx/tsx element pairs (i.e. non-self-closing tags), just like how Neovim's default `at`/`it` work.