### PR TITLE
fix(typo): `vim.api.util` to `vim.lsp.util`

### DIFF
--- a/lua/nvim-treesitter/textobjects/lsp_interop.lua
+++ b/lua/nvim-treesitter/textobjects/lsp_interop.lua
@@ -114,7 +114,7 @@ function M.peek_definition_code(query_string, query_group, lsp_request, context)
     local win_id = vim.api.nvim_get_current_win()
     local params = vim.fn.has "nvim-0.11" == 0 and vim.lsp.util.make_position_params()
       or function(client)
-        return vim.api.util.make_position_params(win_id, client.offset_encoding)
+        return vim.lsp.util.make_position_params(win_id, client.offset_encoding)
       end
     return vim.lsp.buf_request(
       0,


### PR DESCRIPTION
This PR solves a bug introduced in 4fc5b1e for nvim-0.11.
`make_position_params()` is in `vim.lsp.util`, not in `vim.api.util`.