### PR TITLE
feat(ecma): refine class.inner text object selection

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -72,6 +72,9 @@
     (#make-range! "function.inner" @_start @_end)))
 
 (class_declaration
+  body: (class_body)) @class.outer
+
+(class_declaration
   body: (class_body
     .
     "{"

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -72,7 +72,15 @@
     (#make-range! "function.inner" @_start @_end)))
 
 (class_declaration
-  body: (class_body) @class.inner) @class.outer
+  body: (class_body
+    .
+    "{"
+    .
+    (_) @_start @_end
+    (_)? @_end
+    .
+    "}"
+    (#make-range! "class.inner" @_start @_end)))
 
 (export_statement
   (class_declaration)) @class.outer


### PR DESCRIPTION
Replace basic node capture for class.inner with make-range! implementation to select class body content without including braces. This makes class.inner behavior consistent with function.inner, providing a more intuitive text object selection for editing class contents.