### PR TITLE
fix (kotlin): capture `@class.outer` on classes without a body

### DIFF
--- a/queries/kotlin/textobjects.scm
+++ b/queries/kotlin/textobjects.scm
@@ -2,7 +2,7 @@
   [
     (class_body)
     (enum_class_body)
-  ] @class.inner) @class.outer
+  ]? @class.inner) @class.outer
 
 [
   (function_declaration


### PR DESCRIPTION
In Kotlin classes, the body is optional, but the `@class` text objects were failing to capture classes without a body.
This change makes `@class.outer` work for those cases, but `@class.inner` is ignored since these classes does not have an "inner"