### PR TITLE
fix(jsx): use `@attribute.*` over `@parameter.*`

### DIFF
--- a/queries/jsx/textobjects.scm
+++ b/queries/jsx/textobjects.scm
@@ -1,5 +1,8 @@
 ; inherits: ecma
 
+(jsx_attribute) @attribute.outer
+
 (jsx_attribute
   (property_identifier)
-  (_) @parameter.inner) @parameter.outer
+  (_
+    (_) @attribute.inner))


### PR DESCRIPTION
In React, it was using `@parameter.*` queries when there was already a more appropriate one called `@attribute`.

I also made it analogous to the HTML's selection by selecting the inner part of the string/variable with `@attribute.inner`.

Before: `@parameter.inner`

```jsx
<Button variant="text">This is a button</Button>
//              ╰────╯
```

After: `@attribute.inner`

```jsx
<Button variant="text">This is a button</Button>
//               ╰──╯
```