### PR TITLE
fix(python):fix class/function with decorator

### DIFF
--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -1,10 +1,14 @@
-((decorated_definition)?
-  (function_definition
-    body: (block)? @function.inner)) @function.outer
+(decorated_definition
+  (function_definition)) @function.outer
 
-((decorated_definition)?
-  (class_definition
-    body: (block)? @class.inner)) @class.outer
+(function_definition
+  body: (block)? @function.inner) @function.outer
+
+(decorated_definition
+  (class_definition)) @class.outer
+
+(class_definition
+  body: (block)? @class.inner) @class.outer
 
 (while_statement
   body: (block)? @loop.inner) @loop.outer


### PR DESCRIPTION
If in the same file you have both class/function with decorator and without it then move/select won't work for class/function without decorator. I found this bug in the `main` branch, so maybe main problem not in the query, but this fix works.