### PR TITLE
feat(enforce): add enforce queries

### DIFF
--- a/queries/enforce/textobjects.scm
+++ b/queries/enforce/textobjects.scm
@@ -1,0 +1,55 @@
+[
+  (comment_line)
+  (comment_block)
+  (doc_line)
+  (doc_block)
+] @comment.outer
+
+[
+  (literal_int)
+  (literal_float)
+] @number.inner
+
+; TODO: capture inside braces
+(decl_class
+  body: (_) @class.inner) @class.outer
+
+(decl_method
+  body: (_) @function.inner) @function.outer
+
+(for
+  body: (_) @loop.inner) @loop.outer
+
+(while
+  body: (_) @loop.inner) @loop.outer
+
+(return
+  (_)? @return.inner) @return.outer
+
+; blocks
+(block) @block.outer
+
+(invokation) @call.outer
+
+; parameters
+(formal_parameters
+  "," @parameter.outer
+  .
+  (formal_parameter) @parameter.inner @parameter.outer)
+
+(formal_parameters
+  .
+  (_) @parameter.inner @parameter.outer
+  .
+  ","? @parameter.outer)
+
+(actual_parameters
+  "," @parameter.outer
+  .
+  (_) @parameter.inner @parameter.outer)
+
+(actual_parameters
+  .
+  (_) @parameter.inner @parameter.outer
+  .
+  ","? @parameter.outer)


### PR DESCRIPTION
This PR adds back again queries for the Enforce language (currently only available on the master branch)

Compared to the version on master, the queries don't use `make-range` anymore