### PR TITLE
fix(repeatable_move): bug when nil was returned or normal command used; no longer requires { expr = true }

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ local ts_repeat_move = require "nvim-treesitter-textobjects.repeatable_move"
 
 -- Repeat movement with ; and ,
 -- ensure ; goes forward and , goes backward regardless of the last direction
-vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next, { expr = true })
-vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous, { expr = true })
+vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next)
+vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous)
 
 -- vim way: ; goes to the direction you were moving.
 -- vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move)

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -27,18 +27,17 @@ M.make_repeatable_move = function(move_fn)
 end
 
 ---@param opts_extend TSTextObjects.MoveOpts?
----@return string?
 M.repeat_last_move = function(opts_extend)
   if not M.last_move then
     return
   end
   local opts = vim.tbl_deep_extend('force', M.last_move.opts, opts_extend or {})
   if M.last_move.func == 'f' or M.last_move.func == 't' then
-    return opts.forward and ';' or ','
+    vim.api.nvim_feedkeys(vim.v.count1 .. (opts.forward and ';' or ','), 'n', true)
   elseif M.last_move.func == 'F' or M.last_move.func == 'T' then
-    return opts.forward and ',' or ';'
+    vim.api.nvim_feedkeys(vim.v.count1 .. (opts.forward and ',' or ';'), 'n', true)
   else
-    return M.last_move.func(opts, unpack(M.last_move.additional_args))
+    M.last_move.func(opts, unpack(M.last_move.additional_args))
   end
 end
 

--- a/lua/nvim-treesitter-textobjects/repeatable_move.lua
+++ b/lua/nvim-treesitter-textobjects/repeatable_move.lua
@@ -33,9 +33,9 @@ M.repeat_last_move = function(opts_extend)
   end
   local opts = vim.tbl_deep_extend('force', M.last_move.opts, opts_extend or {})
   if M.last_move.func == 'f' or M.last_move.func == 't' then
-    vim.api.nvim_feedkeys(vim.v.count1 .. (opts.forward and ';' or ','), 'n', true)
+    vim.cmd([[normal! ]] .. vim.v.count1 .. (opts.forward and ';' or ','))
   elseif M.last_move.func == 'F' or M.last_move.func == 'T' then
-    vim.api.nvim_feedkeys(vim.v.count1 .. (opts.forward and ',' or ';'), 'n', true)
+    vim.cmd([[normal! ]] .. vim.v.count1 .. (opts.forward and ',' or ';'))
   else
     M.last_move.func(opts, unpack(M.last_move.additional_args))
   end

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -16,6 +16,7 @@ require('nvim-treesitter-textobjects').setup({
 })
 
 local select = require('nvim-treesitter-textobjects.select')
+
 for _, mode in ipairs({ 'x', 'o' }) do
   vim.keymap.set(mode, 'am', function()
     select.select_textobject('@function.outer', 'textobjects')
@@ -125,6 +126,7 @@ end)
 
 -- move
 local move = require('nvim-treesitter-textobjects.move')
+
 vim.keymap.set({ 'n', 'x', 'o' }, ']m', function()
   move.goto_next_start('@function.outer')
 end)
@@ -393,19 +395,20 @@ vim.keymap.set({ 'n', 'x', 'o' }, '[[E', function()
   move.goto_previous_end('@scopename.inner')
 end)
 
+-- repeat
+local ts_repeat_move = require('nvim-treesitter-textobjects.repeatable_move')
+
 -- Repeat movement with ; and ,
 -- ensure ; goes forward and , goes backward regardless of the last direction
--- vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next, { expr = true })
--- vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous, { expr = true })
-
-local repeat_move = require('nvim-treesitter-textobjects.repeatable_move')
+vim.keymap.set({ 'n', 'x', 'o' }, ';', ts_repeat_move.repeat_last_move_next)
+vim.keymap.set({ 'n', 'x', 'o' }, ',', ts_repeat_move.repeat_last_move_previous)
 
 -- vim way: ; goes to the direction you were moving.
-vim.keymap.set({ 'n', 'x', 'o' }, ';', repeat_move.repeat_last_move, { expr = true })
-vim.keymap.set({ 'n', 'x', 'o' }, ',', repeat_move.repeat_last_move_opposite, { expr = true })
+-- vim.keymap.set({ 'n', 'x', 'o' }, ';', ts_repeat_move.repeat_last_move)
+-- vim.keymap.set({ 'n', 'x', 'o' }, ',', ts_repeat_move.repeat_last_move_opposite)
 
 -- Optionally, make builtin f, F, t, T also repeatable with ; and ,
-vim.keymap.set({ 'n', 'x', 'o' }, 'f', repeat_move.builtin_f_expr, { expr = true })
-vim.keymap.set({ 'n', 'x', 'o' }, 'F', repeat_move.builtin_F_expr, { expr = true })
-vim.keymap.set({ 'n', 'x', 'o' }, 't', repeat_move.builtin_t_expr, { expr = true })
-vim.keymap.set({ 'n', 'x', 'o' }, 'T', repeat_move.builtin_T_expr, { expr = true })
+vim.keymap.set({ 'n', 'x', 'o' }, 'f', ts_repeat_move.builtin_f_expr, { expr = true })
+vim.keymap.set({ 'n', 'x', 'o' }, 'F', ts_repeat_move.builtin_F_expr, { expr = true })
+vim.keymap.set({ 'n', 'x', 'o' }, 't', ts_repeat_move.builtin_t_expr, { expr = true })
+vim.keymap.set({ 'n', 'x', 'o' }, 'T', ts_repeat_move.builtin_T_expr, { expr = true })


### PR DESCRIPTION
Should fix https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/775

https://github.com/user-attachments/assets/afecce63-6db3-42c8-977b-e1a209ae9c68

Not sure if this fix is already being addressed in another way or refactor process, but just in case, the move_repeatable function was failing when no string was being returned (nil in this case) due to { expr = true } keymap options. 