### PR TITLE
Fix queries for block in rust and ecma script

### DIFF
--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -113,7 +113,8 @@
     ")") @call.outer)
 
 ; blocks
-(statement_block (_) @block.inner ) @block.outer
+(statement_block 
+  (_)? @block.inner ) @block.outer
 
 ; parameters
 ; function ({ x }) ...

--- a/queries/ecma/textobjects.scm
+++ b/queries/ecma/textobjects.scm
@@ -113,8 +113,7 @@
     ")") @call.outer)
 
 ; blocks
-(_
-  (statement_block) @block.inner) @block.outer
+(statement_block (_) @block.inner ) @block.outer
 
 ; parameters
 ; function ({ x }) ...

--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -108,8 +108,8 @@
     "}")) @loop.outer
 
 ; blocks
-(_
-  (block) @block.inner) @block.outer
+(block 
+  (_)? @block.inner) @block.outer
 
 (unsafe_block
   (_)? @block.inner) @block.outer


### PR DESCRIPTION
The blocks in rust and javascript seem very unintuitive to me. When I select @block.inner in rust for example, this gets matched:
<img width="734" height="153" alt="grafik" src="https://github.com/user-attachments/assets/f33eb2f8-a4a3-4425-82fe-a8dcc71b578a" />
This PR changes this, so @block.inner becomes this:
<img width="734" height="161" alt="grafik" src="https://github.com/user-attachments/assets/f3ab2989-833e-48ea-96b4-f899451ad1f8" />