### PR TITLE
fix(c_sharp): @function.outer doesn't match on empty body of method_declaration

### DIFF
--- a/queries/c_sharp/textobjects.scm
+++ b/queries/c_sharp/textobjects.scm
@@ -37,7 +37,7 @@
   body: (block
     .
     "{"
-    _+ @function.inner
+    _* @function.inner
     "}")) @function.outer
 
 (method_declaration
@@ -48,7 +48,7 @@
   body: (block
     .
     "{"
-    _+ @function.inner
+    _* @function.inner
     "}")) @function.outer
 
 (lambda_expression


### PR DESCRIPTION
if @function.inner does not allow empty body, one cannot jump by @function.outer to it