### PR TITLE
fix(c_sharp): exclude `=>` for function.inner of arrow_expression_clause

### DIFF
--- a/queries/c_sharp/textobjects.scm
+++ b/queries/c_sharp/textobjects.scm
@@ -42,6 +42,7 @@
 
 (method_declaration
   body: (arrow_expression_clause
+    "=>"
     _+ @function.inner)) @function.outer
 
 (constructor_declaration


### PR DESCRIPTION
function.inner should not include `=>` in such case.