### PR TITLE
fix(zig): wrap parentheses patterns in arguments node for call_expression

### DIFF
--- a/queries/zig/textobjects.scm
+++ b/queries/zig/textobjects.scm
@@ -56,20 +56,22 @@
 ; arguments
 (call_expression
   function: (_)
-  "("
-  "," @parameter.outer
-  .
-  (_) @parameter.inner @parameter.outer
-  ")")
+  arguments: (arguments
+    "("
+    "," @parameter.outer
+    .
+    (_) @parameter.inner @parameter.outer
+    ")"))
 
 (call_expression
   function: (_)
-  "("
-  .
-  (_) @parameter.inner @parameter.outer
-  .
-  ","? @parameter.outer
-  ")")
+  arguments: (arguments
+    "("
+    .
+    (_) @parameter.inner @parameter.outer
+    .
+    ","? @parameter.outer
+    ")"))
 
 ; comments
 (comment) @comment.outer
@@ -102,6 +104,7 @@
 (call_expression) @call.outer
 
 (call_expression
-  "("
-  _+ @call.inner
-  ")")
+  arguments: (arguments
+    "("
+    _+ @call.inner
+    ")"))


### PR DESCRIPTION
This update adapts the queries to the parser changes.

Fixes: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/813