### PR TITLE
Update fennel set_form grammar structure

### DIFF
--- a/queries/fennel/textobjects.scm
+++ b/queries/fennel/textobjects.scm
@@ -102,9 +102,8 @@
     rhs: (_) @assignment.rhs) @assignment.inner) @assignment.outer
 
 (set_form
-  (binding_pair
-    lhs: (_) @assignment.lhs
-    rhs: (_) @assignment.rhs) @assignment.inner) @assignment.outer
+  lhs: (_) @assignment.lhs @assignment.inner
+  rhs: (_) @assignment.rhs @assignment.inner) @assignment.outer
 
 (let_vars
   (binding_pair


### PR DESCRIPTION
The fennel grammar was updated to [remove binding_pair](https://github.com/alexmozaidze/tree-sitter-fennel/commit/49293d2) from set.

Without this trying to use the queries gives an "impossible pattern" error.