### PR TITLE
feat(zsh): add various textobjects

### DIFF
--- a/queries/zsh/textobjects.scm
+++ b/queries/zsh/textobjects.scm
@@ -1,1 +1,37 @@
-; inherits: bash
+(function_definition) @function.outer
+
+(function_definition
+  body: (compound_statement
+    .
+    "{"
+    _+ @function.inner
+    "}"))
+
+(case_statement) @conditional.outer
+
+(if_statement
+  (_) @conditional.inner) @conditional.outer
+
+(for_statement
+  (_) @loop.inner) @loop.outer
+
+(while_statement
+  (_) @loop.inner) @loop.outer
+
+(comment) @comment.outer
+
+(regex) @regex.inner
+
+((word) @number.inner
+  (#lua-match? @number.inner "^[0-9]+$"))
+
+(variable_assignment) @assignment.outer
+
+(variable_assignment
+  name: (_) @assignment.inner @assignment.lhs)
+
+(variable_assignment
+  value: (_) @assignment.inner @assignment.rhs)
+
+(command
+  argument: (word) @parameter.inner)


### PR DESCRIPTION
nvim-treesitter has recently added zsh support: https://github.com/nvim-treesitter/nvim-treesitter/pull/8240

Since zsh and bash are so similar, simply inheriting the bash textobject queries appears to work just fine. At least all cases I tried do work.