### PR TITLE
feat(jsonc,git_config): add `@comment.outer` textobject

### DIFF
--- a/queries/git_config/textobjects.scm
+++ b/queries/git_config/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.outer

--- a/queries/jsonc/textobjects.scm
+++ b/queries/jsonc/textobjects.scm
@@ -1,0 +1,1 @@
+(comment) @comment.outer


### PR DESCRIPTION
adds `@comment.outer` for `jsonc` and `git_config`

edit: Not sure what the failing test is supposed to mean, since I did not change the README and I thought the large table was auto-generated?