### PR TITLE
feat(ocaml): include "in" keyword in function.outer

### DIFF
--- a/queries/ocaml/textobjects.scm
+++ b/queries/ocaml/textobjects.scm
@@ -1,6 +1,8 @@
-(value_definition
+((value_definition
   (let_binding
-    body: (_) @function.inner)) @function.outer
+    body: (_) @function.inner)) @_fun_start @_fun_end
+  ("in")? @_fun_end
+  (#make-range! "function.outer" @_fun_start @_fun_end))
 
 (method_definition
   body: (_) @function.inner) @function.outer


### PR DESCRIPTION
Make sure the fonction.outer includes the in keyword `in`, e.g.:

let f x = let g y = 1 in f (g 2)
          ^_____________^