### PR TITLE
fix(inko): update queries for 0.4.0

### DIFF
--- a/queries/inko/textobjects.scm
+++ b/queries/inko/textobjects.scm
@@ -80,11 +80,7 @@
     (_) @conditional.inner)?) @conditional.outer
 
 (if
-  alternative: (else
-    (block) @conditional.inner))
-
-(if
-  consequence: (block)? @conditional.inner)
+  consequence: (block) @conditional.inner)
 
 (if
   condition: (_) @conditional.inner)


### PR DESCRIPTION
This changes the queries for version 0.4.0 of the grammar to fix the crash discussed in https://github.com/nvim-treesitter/nvim-treesitter/pull/8320.