### PR TITLE
docs: vim.g.no_plugin_maps to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you are using [lazy.nvim](https://github.com/folke/lazy.nvim), add this to yo
 ```lua
 {
   "nvim-treesitter/nvim-treesitter-textobjects",
+  branch = "main",
   init = function()
     -- Disable entire built-in ftplugin mappings to avoid conflicts.
     -- See https://github.com/neovim/neovim/tree/master/runtime/ftplugin for built-in ftplugins.


### PR DESCRIPTION
1. `vim.g.no_python_maps` or `vim.g.no_plugin_maps` to avoid conflicts. This actually got me because it seems totally working but actually is broken (like repeatable move etc. won't work)
    - A better way is to overwrite the buffer mappings, but it will be too difficult to explain in the main docs unless we actually provide a convenience function that helps mapping.
2. `nvim-next` doesn't support main branch of this plugin, thus removed.
3. I think it's unintuitive that "move function" uses `]m` and "select function" uses `af`, `if`. The standard seems to be using `am` and `im` for selecting function as per https://github.com/neovim/neovim/blob/master/runtime/ftplugin/ruby.vim . I know this is just an example, but keeping the main doc following the common convention helps a lot.