### PR TITLE
docs: comment out blockwise selection_modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ require("nvim-treesitter-textobjects").setup {
     selection_modes = {
       ['@parameter.outer'] = 'v', -- charwise
       ['@function.outer'] = 'V', -- linewise
-      ['@class.outer'] = '<c-v>', -- blockwise
+      -- ['@class.outer'] = '<c-v>', -- blockwise
     },
     -- If you set this to `true` (default is `false`) then any textobject is
     -- extended to include preceding or succeeding whitespace. Succeeding


### PR DESCRIPTION
Avoid accidental misbehaviour when users copy the config.

Resolves #843 