### PR TITLE
feat(python): @parameter for set literals

### DIFF
--- a/queries/python/textobjects.scm
+++ b/queries/python/textobjects.scm
@@ -134,6 +134,17 @@
   .
   ","? @parameter.outer)
 
+(set
+  "," @parameter.outer
+  .
+  (_) @parameter.inner @parameter.outer)
+
+(set
+  .
+  (_) @parameter.inner @parameter.outer
+  .
+  ","? @parameter.outer)
+
 (dictionary
   .
   (pair) @parameter.inner @parameter.outer


### PR DESCRIPTION
@parameter already matches elements of list, tuple and dict literals.

This PR adds support for elements of set literals.