### PR TITLE
test: replace plenary with minimal fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,13 @@ nvim_ts: $(NVIM_TS)
 $(NVIM_TS):
 	git clone --filter=blob:none --single-branch https://github.com/nvim-treesitter/nvim-treesitter -b main $(NVIM_TS)
 
-PLENARY := $(DEPDIR)/plenary.nvim
+PLENTEST := $(DEPDIR)/plentest.nvim
 
-.PHONY: plenary
-plenary: $(PLENARY)
+.PHONY: plentest
+plentest: $(PLENTEST)
 
-$(PLENARY):
-	git clone --filter=blob:none https://github.com/nvim-lua/plenary.nvim $(PLENARY)
+$(PLENTEST):
+	git clone --filter=blob:none https://github.com/nvim-treesitter/plentest.nvim $(PLENTEST)
 
 # actual test targets
 
@@ -124,9 +124,9 @@ docs: $(NVIM) $(NVIM_TS)
 	NVIM_TS=$(NVIM_TS) $(NVIM_BIN) -l scripts/update-builtin-textobjects.lua
 
 .PHONY: tests
-tests: $(NVIM) $(PLENARY) $(NVIM_TS)
-	NVIM_TS=$(NVIM_TS) PLENARY=$(PLENARY) $(NVIM_BIN) --headless --clean -u scripts/minimal_init.lua \
-		-c "PlenaryBustedDirectory tests { minimal_init = './scripts/minimal_init.lua' }"
+tests: $(NVIM) $(PLENTEST) $(NVIM_TS)
+	NVIM_TS=$(NVIM_TS) PLENTEST=$(PLENTEST) $(NVIM_BIN) --headless --clean -u scripts/minimal_init.lua \
+		-c "lua require('plentest').test_directory('tests', { minimal_init = './scripts/minimal_init.lua' })"
 
 .PHONY: all
 all: lua query docs tests

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -1,14 +1,17 @@
 --- Usage:
----   1. Put plenary.nvim and nvim-treesitter in {repo_root}/.test-deps/
+---   1. Put plentest.nvim and nvim-treesitter in {repo_root}/.test-deps/
 ---   2. in repo root, run `nvim -u scripts/minimal_init.lua`
 --- or, just run `make tests`
 local test_root = '.test-deps'
 for _, name in ipairs({ 'config', 'data', 'state', 'cache' }) do
   vim.env[('XDG_%s_HOME'):format(name:upper())] = test_root .. '/' .. name
 end
-vim.opt.runtimepath:append(os.getenv('PLENARY') or (test_root .. '/plenary.nvim'))
-vim.opt.runtimepath:append(os.getenv('NVIM_TS') or (test_root .. '/nvim-treesitter'))
-vim.opt.runtimepath:append('.')
+vim.opt.runtimepath:prepend(os.getenv('PLENTEST') or (test_root .. '/plentest.nvim'))
+vim.opt.runtimepath:prepend(os.getenv('NVIM_TS') or (test_root .. '/nvim-treesitter'))
+vim.opt.runtimepath:prepend('.')
+
+--- ensure that parser directory is on rtp (with --clean)
+vim.opt.runtimepath:prepend(vim.fn.stdpath('data') .. '/site,')
 
 require('nvim-treesitter').install({ 'python' }):wait(300000) -- wait max. 5 minutes
 

--- a/tests/repeatable_move/common.lua
+++ b/tests/repeatable_move/common.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local assert = require('luassert')
-local Path = require('plenary.path')
 
 -- Test in all possible col position
 -- f, F, t, T
@@ -155,7 +154,7 @@ Runner.__index = Runner
 function Runner:new(it, base_dir, buf_opts)
   local runner = {}
   runner.it = it
-  runner.base_dir = Path:new(base_dir)
+  runner.base_dir = base_dir
   runner.buf_opts = buf_opts
   return setmetatable(runner, self)
 end
@@ -163,8 +162,8 @@ end
 function Runner:builtin_find(file, spec, title)
   title = title and title or tostring(spec.row)
   self.it(string.format('%s[%s]', file, title), function()
-    local path = self.base_dir / file
-    M.run_builtin_find_test(path.filename, spec)
+    local path = vim.fs.joinpath(self.base_dir, file)
+    M.run_builtin_find_test(path, spec)
   end)
 end
 

--- a/tests/select/common.lua
+++ b/tests/select/common.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local assert = require('luassert')
-local Path = require('plenary.path')
 
 function M.run_compare_cmds_test(file, spec, equal)
   assert.are.same(1, vim.fn.filereadable(file), string.format('File "%s" not readable', file))
@@ -46,7 +45,7 @@ Runner.__index = Runner
 function Runner:new(it, base_dir, buf_opts)
   local runner = {}
   runner.it = it
-  runner.base_dir = Path:new(base_dir)
+  runner.base_dir = base_dir
   runner.buf_opts = buf_opts
   return setmetatable(runner, self)
 end
@@ -54,8 +53,8 @@ end
 function Runner:compare_cmds(file, spec, title, equal)
   title = title and title or string.format('%s,%s', spec.row, spec.col)
   self.it(string.format('%s[%s]', file, title), function()
-    local path = self.base_dir / file
-    M.run_compare_cmds_test(path.filename, spec, equal == nil and true or equal)
+    local path = vim.fs.joinpath(self.base_dir, file)
+    M.run_compare_cmds_test(path, spec, equal == nil and true or equal)
   end)
 end
 


### PR DESCRIPTION
Problem: plenary.nvim as test runner is overkill and no longer
maintained.

Solution: Replace with a minimal fork based on Neovim API and vendored
luassert.

Follow-up to https://github.com/nvim-treesitter/nvim-treesitter/pull/8592

This finally fixes user config polluting the system-under-testing by running the instances with `--clean` (which requires manual handling of `rtp` in the minimal init to ensure queries and parsers are available; follow-up should add a `nvim-treesitter.setup` call for explicit custom parser and query dir).