### PR TITLE
feat(rust): @parameter.{inner,outer} for ordered_field_declaration_list

### DIFF
--- a/queries/rust/textobjects.scm
+++ b/queries/rust/textobjects.scm
@@ -261,6 +261,26 @@
   .
   "," @parameter.outer .)
 
+(enum_variant
+  body: (ordered_field_declaration_list
+    "," @parameter.outer
+    .
+    (_) @parameter.inner @parameter.outer))
+
+(enum_variant
+  body: (ordered_field_declaration_list
+    .
+    (_) @parameter.inner @parameter.outer
+    .
+    ","? @parameter.outer))
+
+; last element, with trailing comma
+(enum_variant
+  body: (ordered_field_declaration_list
+    (_) @parameter.outer
+    .
+    "," @parameter.outer .))
+
 (struct_item
   body: (field_declaration_list
     "," @parameter.outer


### PR DESCRIPTION
Fix for https://github.com/nvim-treesitter/nvim-treesitter-textobjects/issues/877